### PR TITLE
Skip logging handler if requested

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
-	flagSet.Bool("request-logging", true, "Log requests to stdout")
+	flagSet.Bool("request-logging", false, "Log requests to stdout")
 
 	flagSet.String("provider", "openshift", "OAuth provider")
 	flagSet.String("login-url", "", "Authentication endpoint")

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -142,8 +143,12 @@ func main() {
 		}
 	}
 
+	var h http.Handler = oauthproxy
+	if opts.RequestLogging {
+		h = LoggingHandler(os.Stdout, h, true)
+	}
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging),
+		Handler: h,
 		Opts:    opts,
 	}
 	s.ListenAndServe()


### PR DESCRIPTION
Skip logging handler entirely if requested.
The logging handler with its current implementation prevents the server for handling streaming requests.