### PR TITLE
Add option to force flush upstream response

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":8443", "<addr>:<port> to listen on for HTTPS clients")
+	flagSet.Duration("upstream-flush", time.Duration(5)*time.Millisecond, "force flush upstream responses after this duration(useful for streaming responses). 0 to never force flush. Defaults to 5ms")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.Var(&clientCAs, "tls-client-ca", "paths to CA roots for trusted client certificates for admitting clients (may be given multiple times).")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -91,8 +91,10 @@ func (u *UpstreamProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	u.handler.ServeHTTP(w, r)
 }
 
-func NewReverseProxy(target *url.URL) (proxy *httputil.ReverseProxy) {
-	return httputil.NewSingleHostReverseProxy(target)
+func NewReverseProxy(target *url.URL, UpstreamFlush time.Duration) (proxy *httputil.ReverseProxy) {
+	proxy = httputil.NewSingleHostReverseProxy(target)
+	proxy.FlushInterval = UpstreamFlush
+	return proxy
 }
 func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
 	director := proxy.Director
@@ -130,7 +132,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		case "http", "https":
 			u.Path = ""
 			log.Printf("mapping path %q => upstream %q", path, u)
-			proxy := NewReverseProxy(u)
+			proxy := NewReverseProxy(u, opts.UpstreamFlush)
 			if !opts.PassHostHeader {
 				setProxyUpstreamHostHeader(proxy, u)
 			} else {

--- a/options.go
+++ b/options.go
@@ -19,16 +19,17 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPrefix      string   `flag:"proxy-prefix" cfg:"proxy-prefix"`
-	HttpAddress      string   `flag:"http-address" cfg:"http_address"`
-	HttpsAddress     string   `flag:"https-address" cfg:"https_address"`
-	RedirectURL      string   `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID         string   `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-	ClientSecret     string   `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-	ClientSecretFile string   `flag:"client-secret-file" cfg:"client_secret_file" env:"OAUTH2_PROXY_CLIENT_SECRET_FILE"`
-	TLSCertFile      string   `flag:"tls-cert" cfg:"tls_cert_file"`
-	TLSKeyFile       string   `flag:"tls-key" cfg:"tls_key_file"`
-	TLSClientCAFiles []string `flag:"tls-client-ca" cfg:"tls_client_ca"`
+	ProxyPrefix      string        `flag:"proxy-prefix" cfg:"proxy-prefix"`
+	HttpAddress      string        `flag:"http-address" cfg:"http_address"`
+	HttpsAddress     string        `flag:"https-address" cfg:"https_address"`
+	UpstreamFlush    time.Duration `flag:"upstream-flush" cfg:"upstream_flush"`
+	RedirectURL      string        `flag:"redirect-url" cfg:"redirect_url"`
+	ClientID         string        `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+	ClientSecret     string        `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
+	ClientSecretFile string        `flag:"client-secret-file" cfg:"client_secret_file" env:"OAUTH2_PROXY_CLIENT_SECRET_FILE"`
+	TLSCertFile      string        `flag:"tls-cert" cfg:"tls_cert_file"`
+	TLSKeyFile       string        `flag:"tls-key" cfg:"tls_key_file"`
+	TLSClientCAFiles []string      `flag:"tls-client-ca" cfg:"tls_client_ca"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
@@ -96,6 +97,7 @@ func NewOptions() *Options {
 		ProxyPrefix:         "/oauth2",
 		HttpAddress:         "127.0.0.1:4180",
 		HttpsAddress:        ":443",
+		UpstreamFlush:       time.Duration(5)*time.Millisecond,
 		DisplayHtpasswdForm: true,
 		CookieName:          "_oauth2_proxy",
 		CookieSecure:        true,


### PR DESCRIPTION
```
  -upstream-flush duration
    	force flush upstream responses after this duration(useful for streaming responses). 0(default) to never force flush
```