### PR TITLE
Better handling of CA trust roots loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	skipAuthRegex := StringArray{}
 	openshiftCAs := StringArray{}
 	clientCAs := StringArray{}
+	upstreamCAs := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -88,6 +89,7 @@ func main() {
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
+	flagSet.Var(&upstreamCAs, "upstream-ca", "paths to CA roots for the Upstream (target) Server (may be given multiple times, defaults to system trust store).")
 
 	providerOpenShift := openshift.New()
 	providerOpenShift.Bind(flagSet)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -39,7 +39,7 @@ func TestNewReverseProxy(t *testing.T) {
 	backendHost := net.JoinHostPort(backendHostname, backendPort)
 	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
 
-	proxyHandler := NewReverseProxy(proxyURL, 5*time.Millisecond)
+	proxyHandler, _ := NewReverseProxy(proxyURL, 5*time.Millisecond, nil)
 	setProxyUpstreamHostHeader(proxyHandler, proxyURL)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
@@ -61,7 +61,7 @@ func TestEncodedSlashes(t *testing.T) {
 	defer backend.Close()
 
 	b, _ := url.Parse(backend.URL)
-	proxyHandler := NewReverseProxy(b, 5*time.Millisecond)
+	proxyHandler, _ := NewReverseProxy(b, 5*time.Millisecond, nil)
 	setProxyDirector(proxyHandler)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()

--- a/options.go
+++ b/options.go
@@ -78,7 +78,8 @@ type Options struct {
 
 	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
-	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	SignatureKey string   `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	UpstreamCAs  []string `flag:"upstream-ca" cfg:"upstream_ca"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func GetCertPool(paths []string) (*x509.CertPool, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("Invalid empty list of Root CAs file paths")
+	}
+	pool := x509.NewCertPool()
+	for _, path := range paths {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("certificate authority file (%s) could not be read - %s", path, err)
+		}
+		if !pool.AppendCertsFromPEM(data) {
+			return nil, fmt.Errorf("loading certificate authority (%s) failed", path)
+		}
+	}
+	return pool, nil
+}


### PR DESCRIPTION
Add only the CA being handled to us in the configuration, and allow
loading a custom CA for contaicting Upstream (target) servers when
proxying.

(backport to release 1.0)