### PR TITLE
Timeout tests after 60 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - echo "Skip go get"
 script:
   - go build .
-  - go test .
+  - go test -timeout 60s .
 
 notifications:
   irc: "chat.freenode.net#openshift-dev"


### PR DESCRIPTION
Tests take less than a minute to run, let's not wait needlessly when they hang.
