### PR TITLE
Fix fsnotify deadlock on linux

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -51,7 +51,6 @@ func WatchForUpdates(filename string, done <-chan bool, action func()) {
 				// can't be opened.
 				if event.Op&(fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) != 0 {
 					log.Printf("watching interrupted on event: %s", event)
-					watcher.Remove(filename)
 					WaitForReplacement(filename, event.Op, watcher)
 				}
 				log.Printf("reloading after event: %s", event)


### PR DESCRIPTION
The watcher.Remove() call added per 020a35e as a fix for Windows behavior
causes a deadlock on linux during a file rename and replace. Remove this call
since we do not care about running on Windows.