### PR TITLE
Use system cert pool for base of CA trusted certs

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -10,7 +10,10 @@ func GetCertPool(paths []string) (*x509.CertPool, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("Invalid empty list of Root CAs file paths")
 	}
-	pool := x509.NewCertPool()
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("could not create system cert pool - %s", err)
+	}
 	for _, path := range paths {
 		data, err := ioutil.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
In 093cf8f1ead451a04ae4adcc37f75de98e3a88ac, the initial cert pool was changed from [system cert pool](https://github.com/openshift/oauth-proxy/commit/093cf8f1ead451a04ae4adcc37f75de98e3a88ac#diff-06e9603a0eb09413fef777eb1a4c2284L130) to an [empty cert pool](https://github.com/openshift/oauth-proxy/commit/093cf8f1ead451a04ae4adcc37f75de98e3a88ac#diff-99f38c7c07bfcc03a528180716bafab5R13). This means that OOTB the oAuth proxy cannot validate server certificates signed by public authorities. This PR fixes that.