### PR TITLE
Allow adding the system roots in addition to a specified ca file

### DIFF
--- a/http.go
+++ b/http.go
@@ -83,7 +83,7 @@ func (s *Server) ServeHTTPS() {
 
 	if len(s.Opts.TLSClientCAFiles) > 0 {
 		config.ClientAuth = tls.RequestClientCert
-		config.ClientCAs, err = util.GetCertPool(s.Opts.TLSClientCAFiles)
+		config.ClientCAs, err = util.GetCertPool(s.Opts.TLSClientCAFiles, false)
 		if err != nil {
 			log.Fatalf("FATAL: %s", err)
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -104,7 +104,7 @@ func NewReverseProxy(target *url.URL, upstreamFlush time.Duration, rootCAs []str
 		IdleConnTimeout:     1 * time.Minute,
 	}
 	if len(rootCAs) > 0 {
-		pool, err := util.GetCertPool(rootCAs)
+		pool, err := util.GetCertPool(rootCAs, false)
 		if err != nil {
 			return nil, err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -4,13 +4,24 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"log"
 )
 
-func GetCertPool(paths []string) (*x509.CertPool, error) {
+func GetCertPool(paths []string, system_roots bool) (*x509.CertPool, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("Invalid empty list of Root CAs file paths")
 	}
-	pool := x509.NewCertPool()
+	var pool *x509.CertPool
+	if system_roots {
+		// ignore errors
+		pool, _ = x509.SystemCertPool()
+		if pool == nil {
+			log.Printf("No system certificates found")
+			pool = x509.NewCertPool()
+		}
+	} else {
+		pool = x509.NewCertPool()
+	}
 	for _, path := range paths {
 		data, err := ioutil.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
This is to allow the openshift provider to be backwards compatible
when it sets the default, which happens every time it does not
have an explicit configuration. Otherwise system roots can never
be automatically queried.

Users are advise to explicitly set the openshift-ca parameter if
they do not want to allow system roots to be trusted.

Addresses the comments on #15 after merge.