### PR TITLE
Pass users' project list in request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Example:
 
 A user who visits the proxy will be redirected to an OAuth login with OpenShift, and must grant
 access to the proxy to view their user info and request permissions for them. Once they have granted
-that right to the proxy, it will check whether the user has the required permissions. If they do 
+that right to the proxy, it will check whether the user has the required permissions. If they do
 not, they'll be given a permission denied error. If they are, they'll be logged in via a cookie.
 
 Run `oc explain subjectaccessreview` to see the schema for a review, including other fields.
@@ -86,7 +86,7 @@ to validate any incoming requests with an `Authorization: Bearer` header or clie
 to be forwarded to the master for verification. If the user authenticates, they are then
 checked against one of the entries in the provided map
 
-The value of the flag is a JSON map of path prefixes to `v1beta1.ResourceAttributes`, and the 
+The value of the flag is a JSON map of path prefixes to `v1beta1.ResourceAttributes`, and the
 longest path prefix is checked. If no path matches the request, authentication and authorization
 are skipped.
 
@@ -107,8 +107,8 @@ Example:
     # Grant access only to paths under /api
     --openshift-delegate-urls='{"/api":{"group":"custom.group","resource":"myproxy""verb":"get"}}'
 
-WARNING: Because users are sending their own credentials to the proxy, it's important to use this 
-setting only when the proxy is under control of the cluster administrators. Otherwise, end users 
+WARNING: Because users are sending their own credentials to the proxy, it's important to use this
+setting only when the proxy is under control of the cluster administrators. Otherwise, end users
 may be unwittingly provide their credentials to untrusted components that can then act as them.
 
 
@@ -116,15 +116,26 @@ may be unwittingly provide their credentials to untrusted components that can th
 
 #### `--openshift-service-account=NAME`
 
-Will attempt to read the `--client-id` and `--client-secret` from the service account information 
+Will attempt to read the `--client-id` and `--client-secret` from the service account information
 injected by OpenShift. Uses the value of `/var/run/secrets/kubernetes.io/serviceaccount/namespace`
-to build the correct `--client-id`, and the contents of 
+to build the correct `--client-id`, and the contents of
 `/var/run/secrets/kubernetes.io/serviceaccount/token` as the `--client-secret`.
 
 #### `--openshift-ca`
 
 One or more paths to CA certificates that should be used when connecting to the OpenShift master.
 If none are provided, the proxy will default to using `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+
+
+#### `--pass-project-headers`
+
+Will request the `user:list-projects` scope from OpenShift OAuth and will get list of projects that the
+user has access to and encode it in the session cookie. Note that if the list of projects changes in
+OpenShift after the user has logged into the oauth-proxy, the change will not be reflected in the header
+value until re-login.
+
+The list of projects will be accessible to upstream with the `X-Forwarded-Projects` header as well as
+`X-Auth-Request-Projects` if `--set-xauthrequest` is also set.
 
 
 ### Discovering the OAuth configuration of an OpenShift cluster
@@ -139,7 +150,7 @@ of OpenShift you can specify these flags directly using the existing flags for t
 In order for service accounts to be used as OAuth clients, they must have the [proper OAuth annotations set](https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients).
 to point to a valid external URL. In most cases, this can be a route exposing the service fronting your
 proxy. We recommend using a `Reencrypt` type route and [service serving certs](https://docs.openshift.org/latest/dev_guide/secrets.html#service-serving-certificate-secrets) to maximize end to end
-security. See [contrib/sidecar.yaml](contrib/sidecar.yaml) for an example of these used in concert. 
+security. See [contrib/sidecar.yaml](contrib/sidecar.yaml) for an example of these used in concert.
 
 By default, the redirect URI of a service account set up as an OAuth client must point to an HTTPS endpoint which
 is a common configuration error.
@@ -215,6 +226,7 @@ Usage of oauth2_proxy:
   -pass-basic-auth: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
   -pass-host-header: pass the request Host Header to upstream (default true)
   -pass-user-headers: pass X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
+  -pass-project-headers: pass users's list of OpenShift projects to upstream via X-Forwarded-Projects header
   -profile-url string: Profile access endpoint
   -provider string: OAuth provider (default "google")
   -proxy-prefix string: the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in) (default "/oauth")

--- a/main.go
+++ b/main.go
@@ -50,7 +50,6 @@ func main() {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.String("debug-address", "", "[http://]<addr>:<port> or unix://<path> to listen on for debug and requests")
-	flagSet.Bool("pass-extra-data", false, "pass provider-specific headers to upstream. This is implemented on a per-provider basis")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
@@ -70,6 +69,7 @@ func main() {
 	flagSet.String("openshift-review-url", "", "Permission check endpoint (defaults to the subject access review endpoint)")
 	flagSet.String("openshift-delegate-urls", "", "If set, perform delegated authorization against the OpenShift API server. Value is a JSON map of path prefixes to v1beta1.ResourceAttribute records that must be granted to the user to continue. E.g. {\"/\":{\"resource\":\"pods\",\"namespace\":\"default\",\"name\":\"test\"}} only allows users who can see the pod test in namespace default.")
 	flagSet.String("openshift-service-account", "", "An optional name of an OpenShift service account to act as. If set, the injected service account info will be used to determine the client ID and client secret.")
+	flagSet.Bool("pass-project-headers", false, "pass users's list of OpenShift projects to upstream via X-Forwarded-Projects header")
 
 	flagSet.String("cookie-name", "_oauth_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies (optionally base64 encoded)")

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.String("debug-address", "", "[http://]<addr>:<port> or unix://<path> to listen on for debug and requests")
+	flagSet.Bool("pass-extra-data", false, "pass provider-specific headers to upstream. This is implemented on a per-provider basis")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -73,6 +73,7 @@ type OAuthProxy struct {
 	PassUserHeaders     bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
+	PassExtraData       bool
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
 	skipAuthPreflight   bool
@@ -232,7 +233,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	log.Printf("Cookie settings: name:%s secure(https):%v httponly:%v expiry:%s domain:%s refresh:%s", opts.CookieName, opts.CookieSecure, opts.CookieHttpOnly, opts.CookieExpire, domain, refresh)
 
 	var cipher *cookie.Cipher
-	if opts.PassAccessToken || (opts.CookieRefresh != time.Duration(0)) {
+	if opts.PassExtraData || opts.PassAccessToken || (opts.CookieRefresh != time.Duration(0)) {
 		var err error
 		cipher, err = cookie.NewCipher(secretBytes(opts.CookieSecret))
 		if err != nil {
@@ -288,6 +289,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PassUserHeaders:    opts.PassUserHeaders,
 		BasicAuthPassword:  opts.BasicAuthPassword,
 		PassAccessToken:    opts.PassAccessToken,
+		PassExtraData:      opts.PassExtraData,
 		SkipProviderButton: opts.SkipProviderButton,
 		CookieCipher:       cipher,
 		templates:          loadTemplates(opts.CustomTemplatesDir),
@@ -329,6 +331,12 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 
 	if s.Email == "" {
 		s.Email, err = p.provider.GetEmailAddress(s)
+	}
+	if p.PassExtraData {
+		s.Extra, err = p.provider.GetExtraData(s)
+		if err != nil {
+			return
+		}
 	}
 	return
 }
@@ -774,10 +782,20 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 			req.Header["X-Forwarded-Email"] = []string{session.Email}
 		}
 	}
+	if p.PassExtraData {
+		for k, v := range session.Extra {
+			req.Header[fmt.Sprintf("X-Forwarded-%s", k)] = []string{v}
+		}
+	}
 	if p.SetXAuthRequest {
 		rw.Header().Set("X-Auth-Request-User", session.User)
 		if session.Email != "" {
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
+		}
+		if p.PassExtraData {
+			for k, v := range session.Extra {
+				rw.Header().Set(fmt.Sprintf("X-Auth-Request-%s", k), v)
+			}
 		}
 	}
 	if p.PassAccessToken && session.AccessToken != "" {

--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	PassExtraData         bool     `flag:"pass-extra-data" cfg:"pass_extra_data"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -116,6 +117,7 @@ func NewOptions() *Options {
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
+		PassExtraData:       false,
 	}
 }
 
@@ -134,7 +136,7 @@ func (o *Options) Validate(p providers.Provider) error {
 	// allow the provider to default some values
 	switch provider := p.(type) {
 	case *openshift.OpenShiftProvider:
-		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftDelegateURLs)
+		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftDelegateURLs, o.PassExtraData)
 		if err != nil {
 			return err
 		}
@@ -220,7 +222,7 @@ func (o *Options) Validate(p providers.Provider) error {
 		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
 	}
 
-	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
+	if o.PassExtraData || o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
 		valid_cookie_secret_size := false
 		for _, i := range []int{16, 24, 32} {
 			if len(secretBytes(o.CookieSecret)) == i {

--- a/options.go
+++ b/options.go
@@ -45,6 +45,7 @@ type Options struct {
 	OpenShiftCAs            []string `flag:"openshift-ca" cfg:"openshift_ca"`
 	OpenShiftServiceAccount string   `flag:"openshift-service-account" cfg:"openshift_service_account"`
 	OpenShiftDelegateURLs   string   `flag:"openshift-delegate-urls" cfg:"openshift_delegate_urls"`
+	PassProjectHeaders      bool     `flag:"pass-project-headers" cfg:"pass_project_headers"`
 
 	CookieName       string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
 	CookieSecret     string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
@@ -66,7 +67,6 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
-	PassExtraData         bool     `flag:"pass-extra-data" cfg:"pass_extra_data"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -117,7 +117,7 @@ func NewOptions() *Options {
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
-		PassExtraData:       false,
+		PassProjectHeaders:  false,
 	}
 }
 
@@ -136,7 +136,7 @@ func (o *Options) Validate(p providers.Provider) error {
 	// allow the provider to default some values
 	switch provider := p.(type) {
 	case *openshift.OpenShiftProvider:
-		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftDelegateURLs, o.PassExtraData)
+		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftDelegateURLs, o.PassProjectHeaders)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (o *Options) Validate(p providers.Provider) error {
 		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
 	}
 
-	if o.PassExtraData || o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
+	if o.PassProjectHeaders || o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
 		valid_cookie_secret_size := false
 		for _, i := range []int{16, 24, 32} {
 			if len(secretBytes(o.CookieSecret)) == i {

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -106,6 +106,10 @@ func (p *ProviderData) GetEmailAddress(s *SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (p *ProviderData) GetExtraData(s *SessionState) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // ValidateGroup validates that the provided email exists in the configured provider
 // email group(s).
 func (p *ProviderData) ValidateGroup(email string) bool {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -11,6 +11,7 @@ type Provider interface {
 	Data() *ProviderData
 
 	GetEmailAddress(*SessionState) (string, error)
+	GetExtraData(*SessionState) (map[string]string, error)
 	Redeem(string, string) (*SessionState, error)
 	ValidateGroup(string) bool
 	ValidateSessionState(*SessionState) bool


### PR DESCRIPTION
This PR allows a provider to add extra headers to the request to upstream. The extra data is encoded in the session cookie and is added to every request. For OpenShift, this means that the requested scope includes listing projects and the request adds the `X-Forwarded-Projects` header with a list of projects that the user is in. 

This data is also available to the auth_request endpoint and can be used in conjunction with auth_request to do extra authorization of the user before allowing the request to be forwarded to upstream.