### PR TITLE
Fix JSON array handling for --openshift-sar

### DIFF
--- a/providers/openshift/provider_test.go
+++ b/providers/openshift/provider_test.go
@@ -1,0 +1,38 @@
+package openshift
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSubjectAccessReviews(t *testing.T) {
+
+	tests := []struct {
+		sar            string
+		expectedResult []string
+	}{
+		{
+			sar: `{"foo":"bar"}`,
+			expectedResult: []string{
+				`{"foo":"bar","scopes":[]}`,
+			},
+		},
+		{
+			sar: `[{"foo":"bar"}, {"baz":"bad"}]`,
+			expectedResult: []string{
+				`{"foo":"bar","scopes":[]}`,
+				`{"baz":"bad","scopes":[]}`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result, err := parseSubjectAccessReviews(test.sar)
+		if err != nil {
+			t.Fatalf("unexpected error %s", err.Error())
+		}
+		if !reflect.DeepEqual(result, test.expectedResult) {
+			t.Fatalf("expected %v, got %v", test.expectedResult, result)
+		}
+	}
+}


### PR DESCRIPTION
The array case in parseSubjectAccessReviews() did not use the index when encoding, so specifying an array of SARs for review was broken. Also refactor to reduce duplicate code.
@enj @simo5 