### PR TITLE
Add -bypass-auth-except-for to protect only paths matched by a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Usage of oauth2_proxy:
   -approval-prompt string: OAuth approval_prompt (default "force")
   -authenticated-emails-file string: authenticate against emails via file (one per line)
   -basic-auth-password string: the password to set when passing the HTTP Basic Auth header
+  -bypass-auth-except-for value: provide authentication ONLY for request paths under proxy-prefix and those that match the given regex (may be given multiple times). Cannot be set with -skip-auth-regex
+  -bypass-auth-for value: alias for -skip-auth-regex
   -client-id string: the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
   -client-secret string: the OAuth Client Secret
   -config string: path to config file
@@ -226,7 +228,7 @@ Usage of oauth2_proxy:
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
-  -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
+  -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times). Cannot be set with -bypass-auth-except-for
   -skip-provider-button: will skip sign-in-page to directly reach the next step: oauth/start
   -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS
   -tls-cert string: path to certificate file

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ func main() {
 	emailDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
+	bypassAuthRegex := StringArray{}
+	bypassAuthExceptRegex := StringArray{}
 	openshiftCAs := StringArray{}
 	clientCAs := StringArray{}
 	upstreamCAs := StringArray{}
@@ -45,7 +47,9 @@ func main() {
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
-	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
+	flagSet.Var(&bypassAuthExceptRegex, "bypass-auth-except-for", "provide authentication ONLY for request paths under proxy-prefix and those that match the given regex (may be given multiple times). Cannot be set with -skip-auth-regex/-bypass-auth-for")
+	flagSet.Var(&bypassAuthRegex, "bypass-auth-for", "alias for skip-auth-regex")
+	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for request paths that match (may be given multiple times). Cannot be set with -bypass-auth-except-for. Alias for -bypass-auth-for")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")

--- a/options_test.go
+++ b/options_test.go
@@ -86,7 +86,7 @@ func TestCompiledRegex(t *testing.T) {
 	o.SkipAuthRegex = regexps
 	assert.Equal(t, nil, o.Validate(&testProvider{}))
 	actual := make([]string, 0)
-	for _, regex := range o.CompiledRegex {
+	for _, regex := range o.CompiledSkipRegex {
 		actual = append(actual, regex.String())
 	}
 	assert.Equal(t, regexps, actual)


### PR DESCRIPTION
This option takes priority over --skip-auth-regex if set. When unset, all paths
are protected by default.
Fixes #42 
@smarterclayton @simo5 @enj please review :)