### PR TITLE
Add --openshift-sar-by-host option to specify SAR rules per hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ Run `oc explain subjectaccessreview` to see the schema for a review, including o
 Specifying multiple rules via a JSON array (`[{...}, {...}]`) will require all permissions to
 be granted.
 
+##### Require specific permissions per host with `--openshift-sar-by-host=JSON`
+
+This is similar to the `--openshift-sar` option but instead of the rules applying to all hosts, you
+can set up specific rules that are checked for a particular upstream host. Using a JSON object the
+keys are hostnames and the value is a JSON array of SAR rules.
+
+Both `--openshift-sar` and `--openshift-sar-by-host` can be used together which will require all
+of the rules from the former as well as any rules that match the host to be satisified for a user
+to be able to access the backed server.
+
+Example:
+
+    # Allows access to foo.example.com if the user can view the service 'proxy' in namespace 'app-dev'
+    --openshift-sar-by-host='{"foo.example.com":{"namespace":"app-dev","resource":"services","name":"proxy","verb":"get"}}'
 
 #### Delegate authentication and authorization to OpenShift for infrastructure
 

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 
 	flagSet.String("openshift-group", "", "restrict logins to members of this group (or groups, if encoded as a JSON array).")
 	flagSet.String("openshift-sar", "", "require this encoded subject access review to authorize (may be a JSON list).")
+	flagSet.String("openshift-sar-by-host", "", "require this encoded subject access review to authorize (must be a JSON array).")
 	flagSet.Var(&openshiftCAs, "openshift-ca", "paths to CA roots for the OpenShift API (may be given multiple times, defaults to /var/run/secrets/kubernetes.io/serviceaccount/ca.crt).")
 	flagSet.String("openshift-review-url", "", "Permission check endpoint (defaults to the subject access review endpoint)")
 	flagSet.String("openshift-delegate-urls", "", "If set, perform delegated authorization against the OpenShift API server. Value is a JSON map of path prefixes to v1beta1.ResourceAttribute records that must be granted to the user to continue. E.g. {\"/\":{\"resource\":\"pods\",\"namespace\":\"default\",\"name\":\"test\"}} only allows users who can see the pod test in namespace default.")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -329,6 +329,13 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 
 	if s.Email == "" {
 		s.Email, err = p.provider.GetEmailAddress(s)
+		if err != nil {
+			return
+		}
+	}
+	err = p.provider.ReviewUser(s.Email, s.AccessToken, host)
+	if err != nil {
+		return nil, err
 	}
 	return
 }

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -342,7 +342,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 
 func (p *OAuthProxy) MakeSessionCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
 	if value != "" {
-		value = cookie.SignedValue(p.CookieSeed, p.CookieName, value, now)
+		value = cookie.SignedValue(fmt.Sprintf("%s%s", p.CookieSeed, req.Host), p.CookieName, value, now)
 		if len(value) > 4096 {
 			// Cookies cannot be larger than 4kb
 			log.Printf("WARNING - Cookie Size: %d bytes", len(value))
@@ -401,7 +401,7 @@ func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionSt
 		// always http.ErrNoCookie
 		return nil, age, fmt.Errorf("Cookie %q not present", p.CookieName)
 	}
-	val, timestamp, ok := cookie.Validate(c, p.CookieSeed, p.CookieExpire)
+	val, timestamp, ok := cookie.Validate(c, fmt.Sprintf("%s%s", p.CookieSeed, req.Host), p.CookieExpire)
 	if !ok {
 		return nil, age, errors.New("Cookie Signature not valid")
 	}

--- a/options.go
+++ b/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	Footer                  string   `flag:"footer" cfg:"footer"`
 
 	OpenShiftSAR            string   `flag:"openshift-sar" cfg:"openshift_sar"`
+	OpenShiftSARByHost      string   `flag:"openshift-sar-by-host" cfg:"openshift_sar_by_host"`
 	OpenShiftReviewURL      string   `flag:"openshift-review-url" cfg:"openshift_review_url"`
 	OpenShiftCAs            []string `flag:"openshift-ca" cfg:"openshift_ca"`
 	OpenShiftServiceAccount string   `flag:"openshift-service-account" cfg:"openshift_service_account"`
@@ -134,7 +135,7 @@ func (o *Options) Validate(p providers.Provider) error {
 	// allow the provider to default some values
 	switch provider := p.(type) {
 	case *openshift.OpenShiftProvider:
-		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftDelegateURLs)
+		defaults, err := provider.LoadDefaults(o.OpenShiftServiceAccount, o.OpenShiftCAs, o.OpenShiftSAR, o.OpenShiftSARByHost, o.OpenShiftDelegateURLs)
 		if err != nil {
 			return err
 		}

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -106,6 +106,10 @@ func (p *ProviderData) GetEmailAddress(s *SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (p *ProviderData) ReviewUser(name, accessToken, host string) (error) {
+	return nil
+}
+
 // ValidateGroup validates that the provided email exists in the configured provider
 // email group(s).
 func (p *ProviderData) ValidateGroup(email string) bool {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -10,6 +10,7 @@ import (
 type Provider interface {
 	Data() *ProviderData
 
+	ReviewUser(name, accessToken, host string) (error)
 	GetEmailAddress(*SessionState) (string, error)
 	Redeem(string, string) (*SessionState, error)
 	ValidateGroup(string) bool


### PR DESCRIPTION
This builds on --openshift-sar by having rules that apply to a specific hostname. In this way oauth-proxy can be used for multiple upstream hosts with different authorization rules. 

In doing this work I realized that the cookie once issued would work for any URL so I append the hostname to the cookie secret so that the cookie only validates for the hostname that it was issued with.