### PR TITLE
Run end-to-end tests in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
 
 install:
   - echo "Skip go get"
+
+before_script:
+  - echo 'DOCKER_OPTS="--insecure-registry 172.30.0.0/16 -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"' | sudo tee --append /etc/default/docker
+  - sudo service docker restart
+  - sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
+  - sudo ps aux | grep docker
+
 script:
   - go build .
   - go test -timeout 60s .
+  - travis_wait 40 test/e2e.sh clusterup
 
 notifications:
   irc: "chat.freenode.net#openshift-dev"
 
-sudo: false
+sudo: true

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3,24 +3,58 @@ set -e
 
 PROJECT_REPO=github.com/openshift/oauth-proxy
 DOCKER_REPO=localhost:5000
+
 KUBECONFIG=~/admin.kubeconfig
 TEST_NAMESPACE=myproject
-TESTDIR=test
+
 REV=$(git rev-parse --short HEAD)
 TEST_IMAGE=${DOCKER_REPO}/oauth-proxy-${REV}:latest
-HELLO_PATH=${TESTDIR}/e2e/hello
+TEST_DIR=$(pwd)/test
+HELLO_PATH=${TEST_DIR}/e2e/hello
 HELLO_IMAGE=${DOCKER_REPO}/hello-proxy-${REV}:latest
+ORIGIN_BUILD_DIR=/tmp/opbuild
+ORIGIN_PATH=${ORIGIN_BUILD_DIR}/src/github.com/openshift/origin
+
+if [ "${1}" == "clusterup" ]; then
+	if [ "${2}" != "nobuild" ]; then
+		if [ ! -d "${ORIGIN_BUILD_DIR}/src" ]; then
+			mkdir -p ${ORIGIN_BUILD_DIR}/src
+		fi
+		GOPATH=${ORIGIN_BUILD_DIR} go get github.com/openshift/origin
+		pushd .
+		cd ${ORIGIN_PATH}
+		# Stabilize on a known working 3.9 commit just for assurance.
+		git checkout 126033b
+		popd
+		GOPATH=${ORIGIN_BUILD_DIR} ${ORIGIN_PATH}/hack/build-go.sh
+	fi
+	export PATH=${ORIGIN_PATH}/_output/local/bin/linux/amd64/:${PATH}
+	openshift version
+
+	# Run bindmountproxy for a non-localhost OpenShift endpoint
+	IP=$(openshift start --print-ip)
+	docker run --privileged --net=host -v /var/run/docker.sock:/var/run/docker.sock -d --name=bindmountproxy cewong/bindmountproxy proxy ${IP}:2375 $(which openshift)
+	sleep 2
+	docker_host=tcp://${IP}:2375
+	DOCKER_HOST=${docker_host} oc cluster up -e DOCKER_HOST=${docker_host}
+
+	sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig ~/
+	sudo chmod 777 ${KUBECONFIG}
+	oc login -u developer -p pass
+	oc project ${TEST_NAMESPACE}
+	oc status
+fi
 
 # build backend site
-go build -o ${HELLO_PATH}/hello_openshift ${PROJECT_REPO}/${HELLO_PATH}
-docker build -t ${HELLO_IMAGE} ${HELLO_PATH}
-docker push ${HELLO_IMAGE}
+go build -o ${HELLO_PATH}/hello_openshift ${PROJECT_REPO}/test/e2e/hello
+sudo docker build -t ${HELLO_IMAGE} ${HELLO_PATH}
+sudo docker push ${HELLO_IMAGE}
 
 # build oauth-proxy
-go build -o ${TESTDIR}/oauth-proxy
-docker build -t ${TEST_IMAGE} ${TESTDIR}/
-docker push ${TEST_IMAGE}
+go build -o ${TEST_DIR}/oauth-proxy
+sudo docker build -t ${TEST_IMAGE} ${TEST_DIR}/
+sudo docker push ${TEST_IMAGE}
 
 # run test
 export TEST_IMAGE TEST_NAMESPACE HELLO_IMAGE KUBECONFIG
-go test -v ${PROJECT_REPO}/${TESTDIR}/e2e
+go test -v ${PROJECT_REPO}/test/e2e


### PR DESCRIPTION
This PR makes a few changes to the e2e testing framework allowing it to run in travis-ci for all PRs. 
The changes include:
* Fetching, building, and starting an OpenShift 3.9 cluster
* Wait on a healthz check of oauth-proxy for each test
* Explicitly use the test namespace for oc commands
