### PR TITLE
Pass OAuth token if delegating to OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ WARNING: Because users are sending their own credentials to the proxy, it's impo
 setting only when the proxy is under control of the cluster administrators. Otherwise, end users 
 may be unwittingly provide their credentials to untrusted components that can then act as them.
 
+When configured for delegation, Oauth Proxy will not set the `X-Forwarded-Access-Token` header on
+the upstream request. If you wish to forward the bearer token received from the client, you will
+have to use the `--pass-user-bearer-token` option in addition to `--openshift-delegate-urls`.
+
+WARNING: With `--pass-user-bearer-token` the client's bearer token will be passed upstream. This
+could pose a security risk if the token is misused or leaked from the upstream service. Bear in
+mind that the tokens received from client could be long term and hard to revoke.
 
 ### Other configuration flags
 
@@ -221,6 +228,7 @@ Usage of oauth-proxy:
   -https-address string: <addr>:<port> to listen on for HTTPS clients (default ":443")
   -login-url string: Authentication endpoint
   -pass-access-token: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
+  -pass-user-bearer-token: pass OAuth access token received from the client to upstream via X-Forwarded-Access-Token header
   -pass-basic-auth: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
   -pass-host-header: pass the request Host Header to upstream (default true)
   -pass-user-headers: pass X-Forwarded-User and X-Forwarded-Email information to upstream (default true)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("pass-user-bearer-token", false, "pass OAuth access token received from the client to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&bypassAuthExceptRegex, "bypass-auth-except-for", "provide authentication ONLY for request paths under proxy-prefix and those that match the given regex (may be given multiple times). Cannot be set with -skip-auth-regex/-bypass-auth-for")
 	flagSet.Var(&bypassAuthRegex, "bypass-auth-for", "alias for skip-auth-regex")

--- a/options.go
+++ b/options.go
@@ -62,6 +62,7 @@ type Options struct {
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassUserBearerToken   bool     `flag:"pass-user-bearer-token" cfg:"pass_user_bearer_token"`
 	PassHostHeader        bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
@@ -116,6 +117,7 @@ func NewOptions() *Options {
 		PassBasicAuth:       true,
 		PassUserHeaders:     true,
 		PassAccessToken:     false,
+		PassUserBearerToken: false,
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,

--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -330,6 +330,8 @@ func (p *OpenShiftProvider) ValidateRequest(req *http.Request) (*providers.Sessi
 		return nil, nil
 	}
 
+	auth := req.Header.Get("Authorization")
+
 	// authenticate
 	user, ok, err := p.authenticator.AuthenticateRequest(req)
 	if err != nil {
@@ -349,7 +351,13 @@ func (p *OpenShiftProvider) ValidateRequest(req *http.Request) (*providers.Sessi
 		log.Printf("authorizer reason: %s", reason)
 		return nil, nil
 	}
-	return &providers.SessionState{User: user.GetName(), Email: user.GetName() + "@cluster.local"}, nil
+
+	parts := strings.SplitN(auth, " ", 2)
+	session := &providers.SessionState{User: user.GetName(), Email: user.GetName() + "@cluster.local"}
+	if parts[0] == "Bearer" {
+		session.AccessToken = parts[1]
+	}
+	return session, nil
 }
 
 func (p *OpenShiftProvider) GetEmailAddress(s *providers.SessionState) (string, error) {

--- a/providers/openshift/provider_test.go
+++ b/providers/openshift/provider_test.go
@@ -1,9 +1,18 @@
 package openshift
 
 import (
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"net/http"
 	"reflect"
 	"testing"
 )
+
+type mockAuthRequestHandler struct {
+}
+
+type mockAuthorizer struct {
+}
 
 func TestParseSubjectAccessReviews(t *testing.T) {
 
@@ -34,5 +43,53 @@ func TestParseSubjectAccessReviews(t *testing.T) {
 		if !reflect.DeepEqual(result, test.expectedResult) {
 			t.Fatalf("expected %v, got %v", test.expectedResult, result)
 		}
+	}
+}
+
+func (mock *mockAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	return &user.DefaultInfo{Name: "username", UID: "uid"}, true, nil
+}
+
+func (mock *mockAuthorizer) Authorize(record authorizer.Attributes) (bool, string, error) {
+	return true, "", nil
+}
+
+func TestPassOAuthToken(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/someurl", nil)
+	req.Header.Set("Authorization", "Bearer this-is-the-token")
+	p := &OpenShiftProvider{}
+	p.paths = recordsByPath{pathRecord{"/someurl", authorizer.AttributesRecord{}}}
+	p.authenticator = &mockAuthRequestHandler{}
+	p.authorizer = &mockAuthorizer{}
+
+	session, err := p.ValidateRequest(req)
+	if err != nil {
+		t.Fatalf("failed to validate request %s", err.Error())
+	}
+	if session == nil {
+		t.Fatal("failed to validate request, no session received")
+	}
+	if g, e := session.AccessToken, "this-is-the-token"; g != e {
+		t.Errorf("access token not set in session to expected value: %v", session)
+	}
+}
+
+func TestDontPassBasicAuthentication(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/someurl", nil)
+	req.Header.Set("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQK")
+	p := &OpenShiftProvider{}
+	p.paths = recordsByPath{pathRecord{"/someurl", authorizer.AttributesRecord{}}}
+	p.authenticator = &mockAuthRequestHandler{}
+	p.authorizer = &mockAuthorizer{}
+
+	session, err := p.ValidateRequest(req)
+	if err != nil {
+		t.Fatalf("failed to validate request %s", err.Error())
+	}
+	if session == nil {
+		t.Fatal("failed to validate request, no session received")
+	}
+	if g, e := session.AccessToken, ""; g != e {
+		t.Errorf("access token should be empty string for basic authentication: %v", session)
 	}
 }


### PR DESCRIPTION
The OAuth token present in the `Authorization` header is not passed to
upstream if delegating authentication/authorization to OpenShift using
`--openshift-delegate-urls`.

This extracts the token from the `Authorization` header and passes it
to upstream via the usual `X-Forwarded-Access-Token` header.