### PR TITLE
Fix cert auth options

### DIFF
--- a/http.go
+++ b/http.go
@@ -81,9 +81,9 @@ func (s *Server) ServeHTTPS() {
 		log.Fatalf("FATAL: loading tls config (%s, %s) failed - %s", s.Opts.TLSCertFile, s.Opts.TLSKeyFile, err)
 	}
 
-	if len(s.Opts.TLSClientCAFiles) > 0 {
+	if len(s.Opts.TLSClientCAFile) > 0 {
 		config.ClientAuth = tls.RequestClientCert
-		config.ClientCAs, err = util.GetCertPool(s.Opts.TLSClientCAFiles, false)
+		config.ClientCAs, err = util.GetCertPool([]string{s.Opts.TLSClientCAFile}, false)
 		if err != nil {
 			log.Fatalf("FATAL: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 	bypassAuthRegex := StringArray{}
 	bypassAuthExceptRegex := StringArray{}
 	openshiftCAs := StringArray{}
-	clientCAs := StringArray{}
+	clientCA := ""
 	upstreamCAs := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
@@ -38,7 +38,7 @@ func main() {
 	flagSet.Duration("upstream-flush", time.Duration(5)*time.Millisecond, "force flush upstream responses after this duration(useful for streaming responses). 0 to never force flush. Defaults to 5ms")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
-	flagSet.Var(&clientCAs, "tls-client-ca", "paths to CA roots for trusted client certificates for admitting clients (may be given multiple times).")
+	flagSet.StringVar(&clientCA, "tls-client-ca", clientCA, "path to a CA file for admitting client certificates.")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
@@ -100,6 +100,7 @@ func main() {
 
 	providerOpenShift := openshift.New()
 	providerOpenShift.Bind(flagSet)
+	providerOpenShift.SetClientCAFile(clientCA)
 
 	flagSet.Parse(os.Args[1:])
 
@@ -109,6 +110,7 @@ func main() {
 	}
 
 	opts := NewOptions()
+	opts.TLSClientCAFile = clientCA
 
 	cfg := make(EnvOptions)
 	if *config != "" {

--- a/options.go
+++ b/options.go
@@ -31,7 +31,7 @@ type Options struct {
 	ClientSecretFile string        `flag:"client-secret-file" cfg:"client_secret_file" env:"OAUTH2_PROXY_CLIENT_SECRET_FILE"`
 	TLSCertFile      string        `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile       string        `flag:"tls-key" cfg:"tls_key_file"`
-	TLSClientCAFiles []string      `flag:"tls-client-ca" cfg:"tls_client_ca"`
+	TLSClientCAFile  string        `flag:"tls-client-ca" cfg:"tls_client_ca"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
@@ -286,7 +286,7 @@ func (o *Options) Validate(p providers.Provider) error {
 			o.CookieExpire.String()))
 	}
 
-	if len(o.TLSClientCAFiles) > 0 && len(o.TLSKeyFile) == 0 && len(o.TLSCertFile) == 0 {
+	if len(o.TLSClientCAFile) > 0 && len(o.TLSKeyFile) == 0 && len(o.TLSCertFile) == 0 {
 		msgs = append(msgs, "tls-client-ca requires tls-key-file or tls-cert-file to be set to listen on tls")
 	}
 

--- a/providers/openshift/authentication.go
+++ b/providers/openshift/authentication.go
@@ -74,13 +74,6 @@ type ClientCertAuthenticationOptions struct {
 	ClientCA string
 }
 
-func (s *ClientCertAuthenticationOptions) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&s.ClientCA, "client-ca-file", s.ClientCA, ""+
-		"If set, any request presenting a client certificate signed by one of "+
-		"the authorities in the client-ca-file is authenticated with an identity "+
-		"corresponding to the CommonName of the client certificate.")
-}
-
 // DelegatingAuthenticationOptions provides an easy way for composing API servers to delegate their authentication to
 // the root kube API server.  The API federator will act as
 // a front proxy and direction connections will be able to delegate to the core kube API server
@@ -124,7 +117,6 @@ func (s *DelegatingAuthenticationOptions) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&s.CacheTTL, "authentication-token-webhook-cache-ttl", s.CacheTTL,
 		"The duration to cache responses from the webhook token authenticator.")
 
-	s.ClientCert.AddFlags(fs)
 	s.RequestHeader.AddFlags(fs)
 }
 

--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -56,6 +56,10 @@ func New() *OpenShiftProvider {
 	return p
 }
 
+func (p *OpenShiftProvider) SetClientCAFile(file string) {
+	p.AuthenticationOptions.ClientCert.ClientCA = file
+}
+
 func (p *OpenShiftProvider) Bind(flags *flag.FlagSet) {
 	p.AuthenticationOptions.AddFlags(flags)
 	p.AuthorizationOptions.AddFlags(flags)


### PR DESCRIPTION
Let --tls-client-ca both enable client cert authentication in the OpenShift
provider and allow oauth-proxy to request a client cert. As a result this
removes the --client-ca-file option and changes --tls-client-ca to only allow
being specified once.
/cc @enj @ericavonb 