### PR TITLE
openshift provider: refetch oauth endpoints on login

### DIFF
--- a/options.go
+++ b/options.go
@@ -153,12 +153,6 @@ func (o *Options) Validate(p providers.Provider) error {
 		if len(o.Scope) == 0 {
 			o.Scope = defaults.Scope
 		}
-		if len(o.LoginURL) == 0 && defaults.LoginURL != nil {
-			o.LoginURL = defaults.LoginURL.String()
-		}
-		if len(o.RedeemURL) == 0 && defaults.RedeemURL != nil {
-			o.RedeemURL = defaults.RedeemURL.String()
-		}
 		if len(o.ValidateURL) == 0 && defaults.ValidateURL != nil {
 			o.ValidateURL = defaults.ValidateURL.String()
 		}
@@ -318,8 +312,9 @@ func (o *Options) validateProvider(provider providers.Provider) []string {
 		ClientSecret:   o.ClientSecret,
 		ApprovalPrompt: o.ApprovalPrompt,
 	}
-	data.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
-	data.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
+	data.ConfigLoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
+	data.ConfigRedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
+
 	data.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
 	data.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 	if len(msgs) != 0 {

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,14 +5,20 @@ import (
 )
 
 type ProviderData struct {
-	ProviderName      string
-	ClientID          string
-	ClientSecret      string
-	LoginURL          *url.URL
-	RedeemURL         *url.URL
+	ProviderName string
+	ClientID     string
+	ClientSecret string
+	// LoginURL, RedeemURL are cached in runtime, only set/unset
+	// them in cache-related methods
+	LoginURL  *url.URL
+	RedeemURL *url.URL
+	// Config* attributes are attributes that are set in options and override
+	// the cached attributes above
+	ConfigLoginURL    *url.URL
+	ConfigRedeemURL   *url.URL
+	ValidateURL       *url.URL
 	ProfileURL        *url.URL
 	ProtectedResource *url.URL
-	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"errors"
 	"net/http"
+	"net/url"
 
 	"github.com/openshift/oauth-proxy/cookie"
 )
@@ -10,16 +11,19 @@ import (
 type Provider interface {
 	Data() *ProviderData
 
-	ReviewUser(name, accessToken, host string) (error)
+	ReviewUser(name, accessToken, host string) error
 	GetEmailAddress(*SessionState) (string, error)
-	Redeem(string, string) (*SessionState, error)
+	Redeem(*url.URL, string, string) (*SessionState, error)
 	ValidateGroup(string) bool
 	ValidateSessionState(*SessionState) bool
-	GetLoginURL(redirectURI, finalRedirect string) string
+	GetLoginRedirectURL(loginURL url.URL, redirectURI, state string) string
 	RefreshSessionIfNeeded(*SessionState) (bool, error)
 	SessionFromCookie(string, *cookie.Cipher) (*SessionState, error)
 	CookieForSession(*SessionState, *cookie.Cipher) (string, error)
 	ValidateRequest(*http.Request) (*SessionState, error)
+	GetLoginURL() *url.URL
+	GetRedeemURL() *url.URL
+	ClearEndpointsCache()
 }
 
 // ErrPermissionDenied may be returned from Redeem() to indicate the user is not allowed to login.


### PR DESCRIPTION
Adds refetching of oauth endpoints and endpoints based on them
when a user tries to do a login. This happens unless these are
hardcoded by user config when the binary is started.

The provider will try to refetch the information also in the cases
where the fetching during login originally failed, but the endpoint
information is required for whatever different purpose.

-----

The number of refetched endpoints URLs will reduced when https://github.com/openshift/oauth-proxy/pull/100 is merged.

cc @openshift/sig-auth 