### PR TITLE
providers: don't cache login and redeem URLs

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -185,12 +185,12 @@ func NewTestProvider(provider_url *url.URL, email_address string) *TestProvider 
 	return &TestProvider{
 		ProviderData: &providers.ProviderData{
 			ProviderName: "Test Provider",
-			LoginURL: &url.URL{
+			ConfigLoginURL: &url.URL{
 				Scheme: "http",
 				Host:   provider_url.Host,
 				Path:   "/oauth/authorize",
 			},
-			RedeemURL: &url.URL{
+			ConfigRedeemURL: &url.URL{
 				Scheme: "http",
 				Host:   provider_url.Host,
 				Path:   "/oauth/token",

--- a/options.go
+++ b/options.go
@@ -336,8 +336,8 @@ func (o *Options) validateProvider(provider providers.Provider) []string {
 		p.ClientID = data.ClientID
 		p.ClientSecret = data.ClientSecret
 		p.ApprovalPrompt = data.ApprovalPrompt
-		p.LoginURL = data.LoginURL
-		p.RedeemURL = data.RedeemURL
+		p.ConfigLoginURL = data.ConfigLoginURL
+		p.ConfigRedeemURL = data.ConfigRedeemURL
 		p.ProfileURL = data.ProfileURL
 		p.ValidateURL = data.ValidateURL
 	}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -8,12 +8,8 @@ type ProviderData struct {
 	ProviderName string
 	ClientID     string
 	ClientSecret string
-	// LoginURL, RedeemURL are cached in runtime, only set/unset
-	// them in cache-related methods
-	LoginURL  *url.URL
-	RedeemURL *url.URL
-	// Config* attributes are attributes that are set in options and override
-	// the cached attributes above
+	// Config* attributes are set in the options, if set, these endpoints won't
+	// be refetched
 	ConfigLoginURL    *url.URL
 	ConfigRedeemURL   *url.URL
 	ValidateURL       *url.URL

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -127,22 +127,18 @@ func (p *ProviderData) RefreshSessionIfNeeded(s *SessionState) (bool, error) {
 	return false, nil
 }
 
-func (p *ProviderData) GetLoginURL() *url.URL {
+func (p *ProviderData) GetLoginURL() (*url.URL, error) {
 	if !(p.ConfigLoginURL == nil || p.ConfigLoginURL.String() == "") {
-		return p.ConfigLoginURL
+		return p.ConfigLoginURL, nil
 	}
 
-	return p.LoginURL
+	return nil, fmt.Errorf("no login endpoint was configured")
 }
 
-func (p *ProviderData) GetRedeemURL() *url.URL {
+func (p *ProviderData) GetRedeemURL() (*url.URL, error) {
 	if !(p.ConfigRedeemURL == nil || p.ConfigRedeemURL.String() == "") {
-		return p.ConfigRedeemURL
+		return p.ConfigRedeemURL, nil
 	}
-	return p.RedeemURL
-}
 
-func (p *ProviderData) ClearEndpointsCache() {
-	p.LoginURL = nil
-	p.RedeemURL = nil
+	return nil, fmt.Errorf("no redeem endpoint was configured")
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -21,9 +21,8 @@ type Provider interface {
 	SessionFromCookie(string, *cookie.Cipher) (*SessionState, error)
 	CookieForSession(*SessionState, *cookie.Cipher) (string, error)
 	ValidateRequest(*http.Request) (*SessionState, error)
-	GetLoginURL() *url.URL
-	GetRedeemURL() *url.URL
-	ClearEndpointsCache()
+	GetLoginURL() (*url.URL, error)
+	GetRedeemURL() (*url.URL, error)
 }
 
 // ErrPermissionDenied may be returned from Redeem() to indicate the user is not allowed to login.


### PR DESCRIPTION
The code which was caching login and redeem URLs is actually
working in parallel which may cause nil dereferences as the cache
is being wiped out. Don't cache these urls at all.