### PR TITLE
Issue 107: Add option to pass authorization bearer to upstream

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-user-bearer-token", false, "pass OAuth access token received from the client to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("pass-auth-bearer", false, "Pass the OAuth access token to the upstream using the Authorization Bearer header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&bypassAuthExceptRegex, "bypass-auth-except-for", "provide authentication ONLY for request paths under proxy-prefix and those that match the given regex (may be given multiple times). Cannot be set with -skip-auth-regex/-bypass-auth-for")
 	flagSet.Var(&bypassAuthRegex, "bypass-auth-for", "alias for skip-auth-regex")

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -117,7 +117,7 @@ func TestNewReverseProxy(t *testing.T) {
 	backendHost := net.JoinHostPort(backendHostname, backendPort)
 	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
 
-	proxyHandler, _ := NewReverseProxy(proxyURL, 5*time.Millisecond, nil)
+	proxyHandler, _ := NewReverseProxy(proxyURL, 5*time.Millisecond, nil, false)
 	setProxyUpstreamHostHeader(proxyHandler, proxyURL)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
@@ -139,7 +139,7 @@ func TestEncodedSlashes(t *testing.T) {
 	defer backend.Close()
 
 	b, _ := url.Parse(backend.URL)
-	proxyHandler, _ := NewReverseProxy(b, 5*time.Millisecond, nil)
+	proxyHandler, _ := NewReverseProxy(b, 5*time.Millisecond, nil, false)
 	setProxyDirector(proxyHandler)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()

--- a/options.go
+++ b/options.go
@@ -63,6 +63,7 @@ type Options struct {
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassAuthBearer        bool   `flag:"pass-auth-bearer" cfg:"pass_auth_bearer"`
 	PassUserBearerToken   bool     `flag:"pass-user-bearer-token" cfg:"pass_user_bearer_token"`
 	PassHostHeader        bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`

--- a/options.go
+++ b/options.go
@@ -63,7 +63,7 @@ type Options struct {
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
-	PassAuthBearer        bool   `flag:"pass-auth-bearer" cfg:"pass_auth_bearer"`
+	PassAuthBearer        bool     `flag:"pass-auth-bearer" cfg:"pass_auth_bearer"`
 	PassUserBearerToken   bool     `flag:"pass-user-bearer-token" cfg:"pass_user_bearer_token"`
 	PassHostHeader        bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`


### PR DESCRIPTION
Resolves #107 

This adds a new option `--pass-auth-bearer` which causes the proxy to pass the `Authorization: Bearer <TOKEN>` header to upstreams.