### PR TITLE
Add registration mechanism for oauth-proxy variants

### DIFF
--- a/extensions.go
+++ b/extensions.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+
+	"github.com/openshift/oauth-proxy/extensions"
+)
+
+func (proxy *OAuthProxy) registerExtensions(openshiftCAs StringArray) {
+	log.Printf("Registering Extensions....")
+
+	handlers := extensions.New(openshiftCAs)
+	proxy.requestHandlers = append(proxy.requestHandlers, handlers...)
+}

--- a/extensions/registrar.go
+++ b/extensions/registrar.go
@@ -1,0 +1,6 @@
+package extensions
+
+//New is a callback to allow extensions to register with the proxy
+func New(openshiftCAs []string) []RequestHandler {
+	return []RequestHandler{}
+}

--- a/extensions/types.go
+++ b/extensions/types.go
@@ -1,0 +1,41 @@
+package extensions
+
+import (
+	"net/http"
+)
+
+//FnHandlerRequest is a function that can process a request
+type FnHandlerRequest func(req *http.Request, context interface{}) (*http.Request, error)
+
+//RequestHandler if a function that modifies a request.  Execution occurs
+//after authentication but before proxy to upstream
+type RequestHandler interface {
+	//Process the request and return the modification or error
+	Process(req *http.Request, context interface{}) (*http.Request, error)
+	//Name of the request handler
+	Name() string
+}
+
+//SimpleRequestHandler is a simple container to modify requests
+type SimpleRequestHandler struct {
+	name      string
+	processor FnHandlerRequest
+}
+
+//Name of the requesthandler
+func (h *SimpleRequestHandler) Name() string {
+	return h.name
+}
+
+//Process the Request
+func (h *SimpleRequestHandler) Process(req *http.Request, context interface{}) (*http.Request, error) {
+	return h.processor(req, context)
+}
+
+//NewRequestHandler creates a named wrapper to a requesthandler function
+func NewRequestHandler(name string, handler FnHandlerRequest) *SimpleRequestHandler {
+	return &SimpleRequestHandler{
+		name,
+		handler,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -167,6 +167,8 @@ func main() {
 		}()
 	}
 
+	oauthproxy.registerExtensions(openshiftCAs)
+
 	var h http.Handler = oauthproxy
 	if opts.RequestLogging {
 		h = LoggingHandler(os.Stdout, h, true)


### PR DESCRIPTION
This PR adds an initial registration mechanism to extend the oauth-proxy to facilitate downstream consumers ability to sync from master.  Cluster Logging wishes to reuse the authentication and SAR bits and then provide additional information to replace our existing multi-tenant plugin.  Ideally we could vendor oauth-proxy but looks like more significant changes are required. 

@mrogers950 @enj thoughts?