### PR TITLE
Bug 1734390: don't log Authorization header when Basic Auth fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
   - echo "Skip go get"
 
 before_script:
-  - echo 'DOCKER_OPTS="--insecure-registry 172.30.0.0/16 -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"' | sudo tee --append /etc/default/docker
-  - sudo service docker restart
+  - "sudo cat /etc/docker/daemon.json | jq '. + {\"insecure-registries\": [\"172.30.0.0/16\"]}' | sudo tee /etc/docker/daemon.json"
+  - sudo systemctl restart docker
   - sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
   - sudo ps aux | grep docker
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -771,7 +771,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	if session == nil {
 		session, err = p.CheckBasicAuth(req)
 		if err != nil {
-			log.Printf("%s %s", remoteAddr, err)
+			log.Printf("basicauth: %s %s", remoteAddr, err)
 		}
 	}
 
@@ -779,7 +779,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	if session == nil {
 		session, err = p.CheckRequestAuth(req)
 		if err != nil {
-			log.Printf("%s %s", remoteAddr, err)
+			log.Printf("requestauth: %s %s", remoteAddr, err)
 		}
 		tokenProvidedByClient = true
 	}
@@ -829,7 +829,7 @@ func (p *OAuthProxy) CheckBasicAuth(req *http.Request) (*providers.SessionState,
 	}
 	s := strings.SplitN(auth, " ", 2)
 	if len(s) != 2 || s[0] != "Basic" {
-		return nil, fmt.Errorf("invalid Authorization header %s", req.Header.Get("Authorization"))
+		return nil, fmt.Errorf("Authorization header does not start with 'Basic', skipping basic authentication")
 	}
 	b, err := b64.StdEncoding.DecodeString(s[1])
 	if err != nil {


### PR DESCRIPTION
Basic auth looks at the Authorization header and checks that its
purpose is to serve for basic auth (starts with "Basic"). It would
log it if this check fails which might print the bearer token in
cases where e.g. service account already has its token and just wants
to access the armored endpoints.

cc @enj @mrogers950 