### PR TITLE
chore(dockerfile.rhel7|OWNERS): update repo ownership

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/oauth-proxy/oauth-proxy /usr/bi
 ENTRYPOINT ["/usr/bin/oauth-proxy"]
 LABEL io.k8s.display-name="OpenShift OAuth Proxy" \
       io.k8s.description="OpenShift OAuth Proxy component of OpenShift" \
-      maintainer="OpenShift Auth Team <aos-auth-team@redhat.com>" \
+      maintainer="OpenShift API Server and Auth Team <aos-apiserver@redhat.com>" \
       name="openshift/oauth-proxy" \
       version="v4.0.0" \
       License="GPLv2+" \

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 reviewers:
 - enj
-- ericavonb
-- mrogers950
+- stlaz
 
 approvers:
 - enj
-- ericavonb
-- mrogers950
+- stlaz
+- sttts
+- deads2k


### PR DESCRIPTION
**Description**

Update owner references to reflect team changes in OpenShift "Group B". This
repo is now owned by the _API Server and Auth Team_, the successor to the now
defunct _Auth Team_.


**Changes**
- Update maintainer label in dockerfile.rhel7 with new team name and email
- Replace reviewers, approvers listed in the OWNERS file with new team membership