### PR TITLE
Bug 1759169: Fix high memory usage

### DIFF
--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bitly/go-simplejson"
@@ -28,6 +29,13 @@ import (
 	authenticationv1beta1 "k8s.io/client-go/pkg/apis/authentication/v1beta1"
 	authorizationv1beta1 "k8s.io/client-go/pkg/apis/authorization/v1beta1"
 )
+
+// httpClientCache stores httpClient objects so that new client does not have to
+// be created on each request just to prevent CAs content changed
+// key is bytes of the hashed metadata of the files for CAs the client was
+// created with
+// NOTE: the entries of the map are currently not being cleaned up
+var httpClientCache sync.Map
 
 func emptyURL(u *url.URL) bool {
 	return u == nil || u.String() == ""
@@ -131,18 +139,29 @@ func (p *OpenShiftProvider) newOpenShiftClient() (*http.Client, error) {
 		capaths = paths
 		system_roots = false
 	}
+
+	// try to retrieve a cached client
+	metadataHash, err := util.GetFilesMetadataHash(capaths)
+	if httpClient, ok := httpClientCache.Load(metadataHash); ok {
+		return httpClient.(*http.Client), nil
+	}
+
+	// client not in cache, create new
 	pool, err := util.GetCertPool(capaths, system_roots)
 	if err != nil {
 		return nil, err
 	}
 
-	return &http.Client{
+	httpClient := &http.Client{
 		Jar: http.DefaultClient.Jar,
 		Transport: &http.Transport{
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: oscrypto.SecureTLSConfig(&tls.Config{RootCAs: pool}),
 		},
-	}, nil
+	}
+	httpClientCache.Store(metadataHash, httpClient)
+
+	return httpClient, nil
 }
 
 // encodeSARWithScope adds a "scopes" array to the SAR if it does not have one already, and outputs

--- a/util/util.go
+++ b/util/util.go
@@ -1,10 +1,16 @@
 package util
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 func GetCertPool(paths []string, system_roots bool) (*x509.CertPool, error) {
@@ -32,4 +38,24 @@ func GetCertPool(paths []string, system_roots bool) (*x509.CertPool, error) {
 		}
 	}
 	return pool, nil
+}
+
+// GetFilesMetadataHash returns base64-encoded hash of (size + name + modtime) of the file at path
+func GetFilesMetadataHash(paths []string) (string, error) {
+	hashData := make([]string, 0, len(paths))
+
+	for _, path := range paths {
+		meta, err := os.Stat(path)
+		if err != nil {
+			return "", fmt.Errorf("couldn't stat '%s': %v", path, err)
+		}
+
+		hashData = append(hashData, meta.Name()+strconv.FormatInt(meta.Size(), 10)+meta.ModTime().String())
+	}
+
+	// sort the strings so that the same paths in different order still generate the same hash
+	sort.Strings(hashData)
+
+	h := sha256.Sum256([]byte(strings.Join(hashData, "")))
+	return base64.StdEncoding.EncodeToString(h[:]), nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,18 +1,18 @@
 package util
 
 import (
-	"testing"
-	"os"
-	"io/ioutil"
-	"reflect"
 	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
 
 	"github.com/bmizerany/assert"
 )
 
 var (
 	testCA1Subj = "301e311c301a060355040313136f617574682d70726f78792074657374206361"
-	testCA1 = `-----BEGIN CERTIFICATE-----
+	testCA1     = `-----BEGIN CERTIFICATE-----
 MIICuTCCAaGgAwIBAgIFAKuKEWowDQYJKoZIhvcNAQELBQAwHjEcMBoGA1UEAxMT
 b2F1dGgtcHJveHkgdGVzdCBjYTAeFw0xNzEwMjQyMDExMzJaFw0xOTEwMjQyMDEx
 MzJaMB4xHDAaBgNVBAMTE29hdXRoLXByb3h5IHRlc3QgY2EwggEiMA0GCSqGSIb3
@@ -31,7 +31,7 @@ pP5YlVqdRCVrxgT80PIMsvQhfcuIrbbeiRDEUdEX7FqebuGCEa2757MTdW7UYQiB
 -----END CERTIFICATE-----
 `
 	testCA2Subj = "3025312330210603550403131a6f617574682d70726f7879207365636f6e642074657374206361"
-	testCA2 = `-----BEGIN CERTIFICATE-----
+	testCA2     = `-----BEGIN CERTIFICATE-----
 MIICxzCCAa+gAwIBAgIFAKuMKewwDQYJKoZIhvcNAQELBQAwJTEjMCEGA1UEAxMa
 b2F1dGgtcHJveHkgc2Vjb25kIHRlc3QgY2EwHhcNMTcxMDI1MTYxMTQxWhcNMTkx
 MDI1MTYxMTQxWjAlMSMwIQYDVQQDExpvYXV0aC1wcm94eSBzZWNvbmQgdGVzdCBj
@@ -64,18 +64,18 @@ func makeTestCertFile(t *testing.T, pem, dir string) *os.File {
 }
 
 func TestGetCertPool(t *testing.T) {
-	_, err := GetCertPool([]string(nil))
+	_, err := GetCertPool([]string(nil), false)
 	if err == nil {
 		t.Errorf("expected an error")
 	}
-	assert.Equal(t, "Invalid empty list of Root CAs file paths" ,err.Error())
+	assert.Equal(t, "Invalid empty list of Root CAs file paths", err.Error())
 
 	tempDir := os.TempDir()
 	defer os.RemoveAll(tempDir)
 	certFile1 := makeTestCertFile(t, testCA1, tempDir)
 	certFile2 := makeTestCertFile(t, testCA2, tempDir)
 
-	certPool, err := GetCertPool([]string{certFile1.Name(), certFile2.Name()})
+	certPool, err := GetCertPool([]string{certFile1.Name(), certFile2.Name()}, false)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}


### PR DESCRIPTION
Creating a new http.client object with every request, re-reading the
CA files, can cause the oauth-proxy container to eventually get
killed with OOM errors as the clients are not actually getting
released anywhere.

Re-use the clients based on checking whether their CA files actually
changed or not - the check for change is based on last-modified
timestamp and size metadata of each CA cert file.

-----

cc @deads2k @sttts 