### PR TITLE
Bug 1826175: Make OpenShift provider's http requests timeout after 1min 

### DIFF
--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -159,6 +159,7 @@ func (p *OpenShiftProvider) newOpenShiftClient() (*http.Client, error) {
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: oscrypto.SecureTLSConfig(&tls.Config{RootCAs: pool}),
 		},
+		Timeout: 1 * time.Minute,
 	}
 	p.httpClientCache.Store(metadataHash, httpClient)
 


### PR DESCRIPTION
The HTTP requests made by the OpenShift provider do not currently apply a HTTP request timeout.  If the  OpenShift Oauth2 Server is in difficulties and fails to respond, the go routines of the HTTP client are leaked.  This problem is also invisible in the oauth-proxy logs.

~~This PR exposes the Provider's HTTP request timeout for configuration by the OAuth Proxy's standard mechanisms (command line, config file, environment).  I have left the default value for the HTTP request timeout to 0, so existing behaviour is unchanged.~~

This PR gives the Provider's HTTP request timeout a reasonable value (1min).

