### PR TITLE
🚧 Allow to configure authenticated users ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ An example [oauth-proxy.cfg](contrib/oauth-proxy.cfg.example) config file is in 
 Usage of oauth-proxy:
   -approval-prompt string: OAuth approval_prompt (default "force")
   -authenticated-emails-file string: authenticate against emails via file (one per line)
+  -authenticated-ids-file string: authenticate against user ids via file (one per line)
+  -authenticated-ids string: authenticate users with the specified id (may be given multiple times). Use * to authenticate any id
   -basic-auth-password string: the password to set when passing the HTTP Basic Auth header
   -bypass-auth-except-for value: provide authentication ONLY for request paths under proxy-prefix and those that match the given regex (may be given multiple times). Cannot be set with -skip-auth-regex
   -bypass-auth-for value: alias for -skip-auth-regex

--- a/contrib/oauth-proxy.cfg.example
+++ b/contrib/oauth-proxy.cfg.example
@@ -35,6 +35,13 @@
 #     "yourcompany.com"
 # ]
 
+## Authenticated IDs to allow authentication for the specified users
+## As an alternative `authenticated_ids_file` may be used
+## To authorize any user use "*"
+# authenticated_ids = [
+#     "f317d52e-955a-419d-bcd6-312482c64fd2"
+# ]
+
 ## The OAuth Client ID, Secret
 # client_id = "123456.apps.googleusercontent.com"
 # client_secret = ""

--- a/options.go
+++ b/options.go
@@ -43,6 +43,9 @@ type Options struct {
 	CustomTemplatesDir      string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 	Footer                  string   `flag:"footer" cfg:"footer"`
 
+	Ids                  []string `flag:"authenticated-ids" cfg:"authenticated_ids"`
+	AuthenticatedIdsFile string   `flag:"authenticated-ids-file" cfg:"authenticated_ids_file"`
+
 	OpenShiftSAR            string   `flag:"openshift-sar" cfg:"openshift_sar"`
 	OpenShiftSARByHost      string   `flag:"openshift-sar-by-host" cfg:"openshift_sar_by_host"`
 	OpenShiftReviewURL      string   `flag:"openshift-review-url" cfg:"openshift_review_url"`
@@ -162,6 +165,9 @@ func (o *Options) Validate(p providers.Provider) error {
 		if len(o.EmailDomains) == 0 {
 			o.EmailDomains = []string{"*"}
 		}
+		if len(o.Ids) == 0 {
+			o.Ids = []string{"*"}
+		}
 		if len(o.RedirectURL) == 0 {
 			o.RedirectURL = "https:///"
 		}
@@ -196,6 +202,9 @@ func (o *Options) Validate(p providers.Provider) error {
 	}
 	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
 		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+	}
+	if o.AuthenticatedIdsFile == "" && len(o.Ids) == 0 && o.HtpasswdFile == "" {
+		msgs = append(msgs, "missing setting for ids validation: ids or authenticated-ids-file required.\n      use ids=* to authorize all users")
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -100,7 +100,7 @@ func (p *ProviderData) SessionFromCookie(v string, c *cookie.Cipher) (s *Session
 	return DecodeSessionState(v, c)
 }
 
-func (p *ProviderData) GetEmailAddress(s *SessionState) (string, error) {
+func (p *ProviderData) GetUserInfo(s *SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -10,9 +10,8 @@ import (
 
 type Provider interface {
 	Data() *ProviderData
-
 	ReviewUser(name, accessToken, host string) error
-	GetEmailAddress(*SessionState) (string, error)
+	GetUserInfo(*SessionState) (string, string, error)
 	Redeem(*url.URL, string, string) (*SessionState, error)
 	ValidateGroup(string) bool
 	ValidateSessionState(*SessionState) bool

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ type SessionState struct {
 	RefreshToken string
 	Email        string
 	User         string
+	UserUID      string
 }
 
 func (s *SessionState) IsExpired() bool {
@@ -72,7 +74,7 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 			return "", err
 		}
 	}
-	return fmt.Sprintf("%s|%s|%d|%s", s.userOrEmail(), a, s.ExpiresOn.Unix(), r), nil
+	return fmt.Sprintf("%s|%s|%s|%d|%s", s.userOrEmail(), s.UserUID, a, s.ExpiresOn.Unix(), r), nil
 }
 
 func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error) {
@@ -85,31 +87,32 @@ func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error)
 		return &SessionState{User: v}, nil
 	}
 
-	if len(chunks) != 4 {
-		err = fmt.Errorf("invalid number of fields (got %d expected 4)", len(chunks))
+	if len(chunks) != 5 {
+		err = fmt.Errorf("invalid number of fields (got %d expected 5)", len(chunks))
 		return
 	}
 
 	s = &SessionState{}
-	if c != nil && chunks[1] != "" {
-		s.AccessToken, err = c.Decrypt(chunks[1])
+	if c != nil && chunks[2] != "" {
+		s.AccessToken, err = c.Decrypt(chunks[2])
 		if err != nil {
 			return nil, err
 		}
 	}
-	if c != nil && chunks[3] != "" {
-		s.RefreshToken, err = c.Decrypt(chunks[3])
+	if c != nil && chunks[4] != "" {
+		s.RefreshToken, err = c.Decrypt(chunks[4])
 		if err != nil {
 			return nil, err
 		}
 	}
+	s.UserUID = chunks[1]
 	if u := chunks[0]; strings.Contains(u, "@") {
 		s.Email = u
 		s.User = strings.Split(u, "@")[0]
 	} else {
 		s.User = u
 	}
-	ts, _ := strconv.Atoi(chunks[2])
+	ts, _ := strconv.Atoi(chunks[3])
 	s.ExpiresOn = time.Unix(int64(ts), 0)
 	return
 }

--- a/string_array_test.go
+++ b/string_array_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"github.com/bmizerany/assert"
+	"testing"
 )
 
 func TestStringArray(t *testing.T) {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -22,12 +22,12 @@ import (
 
 	"golang.org/x/net/html"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"

--- a/user_validator.go
+++ b/user_validator.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/csv"
+	"github.com/openshift/oauth-proxy/providers"
+	"log"
+	"os"
+	"strings"
+	"sync/atomic"
+	"unsafe"
+)
+
+type UserIDMap struct {
+	usersFile string
+	m         unsafe.Pointer
+}
+
+func NewUserIDMap(usersFile string, done <-chan bool, onUpdate func()) *UserIDMap {
+	um := &UserIDMap{usersFile: usersFile}
+	m := make(map[string]bool)
+	atomic.StorePointer(&um.m, unsafe.Pointer(&m))
+	if usersFile != "" {
+		log.Printf("using authenticated uids file %s", usersFile)
+		WatchForUpdates(usersFile, done, func() {
+			um.LoadAuthenticatedUIDsFile()
+			onUpdate()
+		})
+		um.LoadAuthenticatedUIDsFile()
+	}
+	return um
+}
+
+func (um *UserIDMap) IsValid(uid string) (result bool) {
+	m := *(*map[string]bool)(atomic.LoadPointer(&um.m))
+	_, result = m[uid]
+	return
+}
+
+func (um *UserIDMap) LoadAuthenticatedUIDsFile() {
+	r, err := os.Open(um.usersFile)
+	if err != nil {
+		log.Fatalf("failed opening authenticated-uids-file=%q, %s", um.usersFile, err)
+	}
+	defer r.Close()
+	csv_reader := csv.NewReader(r)
+	csv_reader.Comma = ','
+	csv_reader.Comment = '#'
+	csv_reader.TrimLeadingSpace = true
+	records, err := csv_reader.ReadAll()
+	if err != nil {
+		log.Printf("error reading authenticated-uids-file=%q, %s", um.usersFile, err)
+		return
+	}
+	updated := make(map[string]bool)
+	for _, r := range records {
+		uid := strings.TrimSpace(r[0])
+		updated[uid] = true
+	}
+	atomic.StorePointer(&um.m, unsafe.Pointer(&updated))
+}
+
+func newUserValidatorImpl(uids []string, usersFile string,
+	done <-chan bool, onUpdate func()) func(providers.SessionState) bool {
+	validUIDsStorage := NewUserIDMap(usersFile, done, onUpdate)
+
+	var allowAll bool
+	for _, uid := range uids {
+		if uid == "*" {
+			allowAll = true
+			continue
+		}
+	}
+
+	validator := func(s providers.SessionState) (valid bool) {
+		log.Printf("Checking session %s", s.UserUID)
+		log.Printf("Checking %s#%s", s.UserUID, s.User)
+		if s.UserUID == "" {
+			//TODO Kubeadmin does not have uid
+			log.Printf("user id is empty. Returning %b", valid)
+			return
+		}
+		for _, uids := range uids {
+			valid = valid || s.UserUID == uids
+			log.Printf("Comparing %s=%s. is the same: %b, is valid: %b", s.UserUID, uids, s.UserUID == uids, valid)
+		}
+		if !valid {
+			valid = validUIDsStorage.IsValid(s.UserUID)
+		}
+		if allowAll {
+			valid = true
+		}
+		return valid
+	}
+	return validator
+}
+
+func NewUserValidator(ids []string, usersFile string) func(providers.SessionState) bool {
+	return newUserValidatorImpl(ids, usersFile, nil, func() {})
+}

--- a/validator.go
+++ b/validator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
+	"github.com/openshift/oauth-proxy/providers"
 	"log"
 	"os"
 	"strings"
@@ -60,7 +61,7 @@ func (um *UserMap) LoadAuthenticatedEmailsFile() {
 }
 
 func newValidatorImpl(domains []string, usersFile string,
-	done <-chan bool, onUpdate func()) func(string) bool {
+	done <-chan bool, onUpdate func()) func(providers.SessionState) bool {
 	validUsers := NewUserMap(usersFile, done, onUpdate)
 
 	var allowAll bool
@@ -72,11 +73,13 @@ func newValidatorImpl(domains []string, usersFile string,
 		domains[i] = fmt.Sprintf("@%s", strings.ToLower(domain))
 	}
 
-	validator := func(email string) (valid bool) {
-		if email == "" {
+	validator := func(s providers.SessionState) (valid bool) {
+		log.Printf("Checking %s#%s", s.UserUID, s.User)
+		if s.Email == "" {
+			log.Printf("user email is empty. Returning %b", valid)
 			return
 		}
-		email = strings.ToLower(email)
+		email := strings.ToLower(s.Email)
 		for _, domain := range domains {
 			valid = valid || strings.HasSuffix(email, domain)
 		}
@@ -91,6 +94,6 @@ func newValidatorImpl(domains []string, usersFile string,
 	return validator
 }
 
-func NewValidator(domains []string, usersFile string) func(string) bool {
+func NewValidator(domains []string, usersFile string) func(providers.SessionState) bool {
 	return newValidatorImpl(domains, usersFile, nil, func() {})
 }


### PR DESCRIPTION
It's just WIP branch. 
TODOs:
- revise flags list. Now there are `-authenticated-ids-file` and `authenticated-ids`. Probably `authenticated-ids` should be good enough to start;
- consider merging validators;
- cover new functionalities with tests;
- `kube:admin` has no UID. So, proxy could consider empty string as a valid UID.