### PR TITLE
add logoutredirect URL to oauth-proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 
 	flagSet.String("provider", "openshift", "OAuth provider")
 	flagSet.String("login-url", "", "Authentication endpoint")
+	flagSet.String("logout-url", "", "absolute URL to redirect web browsers to after logging out of openshift oauth server")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
 	flagSet.String("validate-url", "", "Access token validation endpoint")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -61,6 +61,8 @@ type OAuthProxy struct {
 	OAuthCallbackPath string
 	AuthOnlyPath      string
 
+	LogoutRedirectURL string
+
 	redirectURL         *url.URL // the url to receive requests at
 	provider            providers.Provider
 	ProxyPrefix         string
@@ -267,6 +269,8 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),
 		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
+
+		LogoutRedirectURL: opts.LogoutRedirectURL,
 
 		ProxyPrefix:         opts.ProxyPrefix,
 		provider:            opts.provider,
@@ -595,7 +599,11 @@ func (p *OAuthProxy) SignIn(rw http.ResponseWriter, req *http.Request) {
 
 func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 	p.ClearSessionCookie(rw, req)
-	http.Redirect(rw, req, "/", 302)
+	redirectURL := "/"
+	if len(p.LogoutRedirectURL) > 0 {
+		redirectURL = p.LogoutRedirectURL
+	}
+	http.Redirect(rw, req, redirectURL, 302)
 }
 
 func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {

--- a/options.go
+++ b/options.go
@@ -83,11 +83,22 @@ type Options struct {
 	ValidateURL    string `flag:"validate-url" cfg:"validate_url"`
 	Scope          string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt string `flag:"approval-prompt" cfg:"approval_prompt"`
-
 	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
 	SignatureKey string   `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 	UpstreamCAs  []string `flag:"upstream-ca" cfg:"upstream_ca"`
+
+	// An optional, absolute URL to redirect web browsers to after logging out of
+	// the console. If not specified, it will redirect to the default login page.
+	// This is required when using an identity provider that supports single
+	// sign-on (SSO) such as:
+	// - OpenID (Keycloak, Azure)
+	// - RequestHeader (GSSAPI, SSPI, SAML)
+	// - OAuth (GitHub, GitLab, Google)
+	// Logging out of the console will destroy the user's token. The logoutRedirect
+	// provides the user the option to perform single logout (SLO) through the identity
+	// provider to destroy their single sign-on session.
+	LogoutRedirectURL       string `flag:"logout-url" cfg:"logout_url"`
 
 	// internal values that are set after config validation
 	redirectURL       *url.URL


### PR DESCRIPTION
Adds `-logout-url=url-to-log-out-of-sso` to be peer to https://github.com/openshift/api/blob/master/config/v1/types_console.go#L50-L63

I think this is logically comparable to https://github.com/openshift/console/blob/4efd97f82f824f56da6a1a627dbbd9d677ba9b63/frontend/public/module/auth.js#L72-L80

/assign @stlaz 

/cc @jcantrill 

The options for exposure are...

1. this PR which makes the redirect based on an oauth-proxy arg. Doing it like this prevents the web app from choosing a redirect URL that varies by user or by where a user is in the app itself. This is limiting, but easy.
1. create a different approach that allows a web app to go to the https://oauth-proxy/sign_out?redirect=foo. This allows webapps to choose any redirect based on any criteria. Based on a conversation with @spadgett, this requires creating a csrf token that is embedded in the page, but the logout is owned by the web app, not the oauth-proxy. That makes creating the csrf impractical.


We should go with option 1