### PR TITLE
Add example use of --openshift-ca argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ to build the correct `--client-id`, and the contents of
 One or more paths to CA certificates that should be used when connecting to the OpenShift master.
 If none are provided, the proxy will default to using `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
 
+You can use this flag to trust the OpenShift OAuth certificate if the [default ingress certificate is changed](https://docs.openshift.com/container-platform/4.3/authentication/certificates/replacing-default-ingress-certificate.html). The new certificate can be added to the container directly, or via a [ConfigMap populated by OpenShift](https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki). For example, you might mount the ConfigMap to `/etc/ocp-injected-certs/tls-ca-bundle.pem`, and add this flag to the argument list of the container: `--openshift-ca=/etc/ocp-injected-certs/tls-ca-bundle.pem`.
+
 
 ### Discovering the OAuth configuration of an OpenShift cluster
 

--- a/contrib/sidecar.yaml
+++ b/contrib/sidecar.yaml
@@ -8,6 +8,13 @@ items:
     name: proxy
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"proxy"}}'
+# Create a ConfigMap which OpenShift will populate with trusted certificates
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+    name: ocp-ca-bundle
 # Create a secure connection to the proxy via a route
 - apiVersion: v1
   kind: Route
@@ -63,9 +70,13 @@ items:
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret=SECRET
+          - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - --openshift-ca=/etc/ocp-injected-certs/tls-ca-bundle.pem
           volumeMounts:
           - mountPath: /etc/tls/private
             name: proxy-tls
+          - mountPath: /etc/ocp-injected-certs
+            name: ocp-injected-certs
 
         - name: app
           image: openshift/hello-openshift:latest
@@ -73,3 +84,9 @@ items:
         - name: proxy-tls
           secret:
             secretName: proxy-tls
+        - name: ocp-injected-certs
+          configMap:
+            name: ocp-ca-bundle
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem


### PR DESCRIPTION
We ran into the problem we think is described in https://github.com/openshift/oauth-proxy/issues/73, and found this as a workaround.

If the default ingress certificate is changed in the cluster, then the OpenShift OAuth server certificate might no longer be trusted by default. However, assuming the certificate was changed with [this procedure (link)](https://docs.openshift.com/container-platform/4.3/authentication/certificates/replacing-default-ingress-certificate.html), then OpenShift will add the new certificate to a bundle which we can mount into the container (more info on that process [here (link)](https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki).

This PR adds a section describing this configuration in the README, and adds it to the example sidecar configuration.