### PR TITLE
Add configuration for cookie 'SameSite' value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Usage of oauth-proxy:
   -cookie-httponly: set HttpOnly cookie flag (default true)
   -cookie-name string: the name of the cookie that the oauth_proxy creates (default "_oauth2_proxy")
   -cookie-refresh duration: refresh the cookie after this duration; 0 to disable
+  -cookie-samesite string | set SameSite cookie attribute (ie: `"lax"`, `"strict"`, `"none"`, or `""`)
   -cookie-secret string: the seed string for secure cookies (optionally base64 encoded)
   -cookie-secret-file string: same as "-cookie-secret" but read it from a file
   -cookie-secure: set secure (HTTPS) cookie flag (default true)
@@ -285,6 +286,7 @@ The following environment variables can be used in place of the corresponding co
 - `OAUTH2_PROXY_CLIENT_ID`
 - `OAUTH2_PROXY_CLIENT_SECRET`
 - `OAUTH2_PROXY_COOKIE_NAME`
+- `OAUTH2_PROXY_COOKIE_SAMESITE`
 - `OAUTH2_PROXY_COOKIE_SECRET`
 - `OAUTH2_PROXY_COOKIE_DOMAIN`
 - `OAUTH2_PROXY_COOKIE_EXPIRE`

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
+	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
 
 	flagSet.Bool("request-logging", false, "Log requests to stdout")
 

--- a/options.go
+++ b/options.go
@@ -58,6 +58,7 @@ type Options struct {
 	CookieRefresh    time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
 	CookieSecure     bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly   bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
+	CookieSameSite   string        `flag:"cookie-samesite" cfg:"cookie_samesite" env:"OAUTH2_PROXY_COOKIE_SAMESITE"`
 
 	Upstreams             []string `flag:"upstream" cfg:"upstreams"`
 	BypassAuthExceptRegex []string `flag:"bypass-auth-except-for" cfg:"bypass_auth_except_for"`
@@ -297,6 +298,12 @@ func (o *Options) Validate(p providers.Provider) error {
 
 	if len(o.TLSClientCAFile) > 0 && len(o.TLSKeyFile) == 0 && len(o.TLSCertFile) == 0 {
 		msgs = append(msgs, "tls-client-ca requires tls-key-file or tls-cert-file to be set to listen on tls")
+	}
+
+	switch o.CookieSameSite {
+	case "", "none", "lax", "strict":
+	default:
+		msgs = append(msgs, fmt.Sprintf("cookie_samesite (%q) must be one of ['', 'lax', 'strict', 'none']", o.CookieSameSite))
 	}
 
 	msgs = parseSignatureKey(o, msgs)

--- a/options_test.go
+++ b/options_test.go
@@ -210,3 +210,22 @@ func TestValidateCookieBadName(t *testing.T) {
 	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
 		fmt.Sprintf("  invalid cookie name: %q", o.CookieName))
 }
+
+func TestValidateCookieSameSiteUnknown(t *testing.T) {
+	o := testOptions()
+	o.CookieSameSite = "foo"
+	err := o.Validate(&testProvider{})
+	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
+		fmt.Sprintf("  cookie_samesite (%q) must be one of ['', 'lax', 'strict', 'none']", o.CookieSameSite))
+}
+
+func TestValidateCookieSameSite(t *testing.T) {
+	testCases := []string{"", "lax", "strict", "none"}
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			o := testOptions()
+			o.CookieSameSite = tc
+			assert.Equal(t, nil, o.Validate(&testProvider{}))
+		})
+	}
+}


### PR DESCRIPTION
Expose the [samesite](https://www.owasp.org/index.php/SameSite) cookie option for configuration.

Values of `lax` and `strict` can improve and mitigate some categories of cross-site traffic tampering.

As oauth-proxy is used to front other components, having this configuration option available makes a useful defence.

Based on Paul Groudas' <paul@clubhouse.io> work (https://github.com/oauth2-proxy/oauth2-proxy/commit/5d0827a)