### PR TITLE
Bug 1884565: don't segfault on wrong option combination

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -18,6 +18,9 @@ func NewStringArray() *StringArray {
 }
 
 func (a StringArray) Get() interface{} {
+	if a.stringArray == nil {
+		return nil
+	}
 	return *a.stringArray
 }
 
@@ -27,5 +30,8 @@ func (a StringArray) Set(s string) error {
 }
 
 func (a StringArray) String() string {
+	if a.stringArray == nil {
+		return ""
+	}
 	return strings.Join(*a.stringArray, ",")
 }

--- a/string_array_test.go
+++ b/string_array_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -19,4 +20,14 @@ func TestStringArray(t *testing.T) {
 		t.Errorf("unexpected error %v", err)
 	}
 	assert.Equal(t, "foo,bar", sa.String())
+}
+
+func TestStringArrayInFlagSet(t *testing.T) {
+	sa := NewStringArray()
+
+	// flagset tries to grab an empty interface of each flag and invokes
+	// their .String() method to check whether they are empty
+	flagSet := flag.NewFlagSet("cool flagset", flag.ExitOnError)
+	flagSet.Var(sa, "favourite colours", "colourful storm")
+	flagSet.PrintDefaults()
 }


### PR DESCRIPTION
Golang flags attempt to use an empty struct when they print
defaults for usage information.