### PR TITLE
Updating golang-github-openshift-oauth-proxy builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR  /go/src/github.com/openshift/oauth-proxy
 COPY . .
 RUN go build .
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=builder /go/src/github.com/openshift/oauth-proxy/oauth-proxy /usr/bin/oauth-proxy
 ENTRYPOINT ["/usr/bin/oauth-proxy"]


### PR DESCRIPTION
Updating golang-github-openshift-oauth-proxy builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/golang-github-openshift-oauth-proxy.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
