### PR TITLE
Bug 1958158: providers/openshift: remove logging of authorizer decisions

### DIFF
--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -399,12 +399,11 @@ func (p *OpenShiftProvider) ValidateRequest(req *http.Request) (*providers.Sessi
 
 	// authorize
 	record.record.User = response.User
-	decision, reason, err := p.authorizer.Authorize(context.Background(), record.record)
+	decision, _, err := p.authorizer.Authorize(context.Background(), record.record)
 	if err != nil {
 		return nil, err
 	}
 	if decision != authorizer.DecisionAllow {
-		log.Printf("authorizer reason: %s", reason)
 		return nil, nil
 	}
 


### PR DESCRIPTION
This prevents log flooding of anomoys requests with no bearer token. This also prevents logging of empty authorizer denial reasons with an initial request against oauth-proxy before it redirects to the login page.

/cc @standa @sttts 