### PR TITLE
Use resourceName in Openshift SAR rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Cons:
 Example:
 
     # Allows access if the user can view the service 'proxy' in namespace 'app-dev'
-    --openshift-sar='{"namespace":"app-dev","resource":"services","name":"proxy","verb":"get"}'
+    --openshift-sar='{"namespace":"app-dev","resource":"services","resourceName":"proxy","verb":"get"}'
 
 A user who visits the proxy will be redirected to an OAuth login with OpenShift, and must grant
 access to the proxy to view their user info and request permissions for them. Once they have granted
@@ -89,7 +89,7 @@ to be able to access the backed server.
 Example:
 
     # Allows access to foo.example.com if the user can view the service 'proxy' in namespace 'app-dev'
-    --openshift-sar-by-host='{"foo.example.com":{"namespace":"app-dev","resource":"services","name":"proxy","verb":"get"}}'
+    --openshift-sar-by-host='{"foo.example.com":{"namespace":"app-dev","resource":"services","resourceName":"proxy","verb":"get"}}'
 
 #### Delegate authentication and authorization to OpenShift for infrastructure
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -83,6 +83,20 @@ func TestOAuthProxyE2E(t *testing.T) {
 			},
 			expectedErr: "did not reach upstream site",
 		},
+		"sar-name-ok": {
+			oauthProxyArgs: []string{
+				"--upstream=http://localhost:8080",
+				`--openshift-sar={"namespace":"` + ns + `","resource":"routes","resourceName":"proxy-route","verb":"get"}`,
+			},
+			pageResult: "URI: /",
+		},
+		"sar-name-fail": {
+			oauthProxyArgs: []string{
+				"--upstream=http://localhost:8080",
+				`--openshift-sar={"namespace":"other","resource":"routes","resourceName":"proxy-route","verb":"get"}`,
+			},
+			expectedErr: "did not reach upstream site",
+		},
 		"sar-multi-ok": {
 			oauthProxyArgs: []string{
 				"--upstream=http://localhost:8080",


### PR DESCRIPTION
If `name` is used the rule is not evaluated correctly because the Openshift SAR only supports `resourceName`.

```
oc explain subjectaccessreview --api-version=authorization.openshift.io/v1
```
