### PR TITLE
Support KUBERNETES_SERVICE_PORT environment variable

### DIFF
--- a/providers/openshift/provider.go
+++ b/providers/openshift/provider.go
@@ -696,6 +696,10 @@ func getKubeAPIURLWithPath(path string) *url.URL {
 		}
 		ret.Host = host
 	}
+	if port := os.Getenv("KUBERNETES_SERVICE_PORT"); len(port) > 0 {
+		ret.Host += ":" + port
+	}
+
 
 	return ret
 }


### PR DESCRIPTION
The `KUBERNETES_SERVICE_HOST` environment variable does not support allowing the user to specify a custom port because it thinks the value is an IPv6 address and wraps in in square brackets.

This change adds support for a second environment variable `KUBERNETES_SERVICE_PORT` to accommodate this situation.