### PR TITLE
OCPBUGS-14033: Handle TERM signal gracefully

### DIFF
--- a/http.go
+++ b/http.go
@@ -21,17 +21,20 @@ type Server struct {
 	Opts    *Options
 }
 
-func (s *Server) ListenAndServe() {
+func (s *Server) ListenAndServe(ctx context.Context) {
 	if s.Opts.HttpsAddress == "" && s.Opts.HttpAddress == "" {
 		log.Fatalf("FATAL: must specify https-address or http-address")
 	}
 	if s.Opts.HttpsAddress != "" {
-		go s.ServeHTTPS()
+		go s.ServeHTTPS(ctx)
 	}
 	if s.Opts.HttpAddress != "" {
 		go s.ServeHTTP()
 	}
-	select {}
+
+	select {
+	case <-ctx.Done():
+	}
 }
 
 func (s *Server) ServeHTTP() {
@@ -69,7 +72,7 @@ func (s *Server) ServeHTTP() {
 	log.Printf("HTTP: closing %s", listener.Addr())
 }
 
-func (s *Server) ServeHTTPS() {
+func (s *Server) ServeHTTPS(ctx context.Context) {
 	addr := s.Opts.HttpsAddress
 
 	config := oscrypto.SecureTLSConfig(&tls.Config{})
@@ -82,7 +85,7 @@ func (s *Server) ServeHTTPS() {
 	if err != nil {
 		log.Fatalf("FATAL: loading tls config (%s, %s) failed - %s", s.Opts.TLSCertFile, s.Opts.TLSKeyFile, err)
 	}
-	go servingCertProvider.Run(context.Background(), 1)
+	go servingCertProvider.Run(ctx, 1)
 
 	config.GetCertificate = func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		// this disregards information from ClientHello but we're not doing SNI anyway


### PR DESCRIPTION
When a pod is evicted, the container runtime will send a TERM signal to the PID 1 of all containers. If a container doesn't catch the signal, the process will exit with a non-zero code and Kubernetes might consider the pod status to be Failed.

See
https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination