### PR TITLE
fix route apiVersion

### DIFF
--- a/contrib/sidecar.yaml
+++ b/contrib/sidecar.yaml
@@ -9,7 +9,7 @@ items:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"proxy"}}'
 # Create a secure connection to the proxy via a route
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     name: proxy


### PR DESCRIPTION
Replaced:
`apiVersion: v1`
with:
`apiVersion: route.openshift.io/v1`

`apiVersion: v1` doesn't work