### PR TITLE
APPSRE-7970: Add support for configuring upstream timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Usage of oauth-proxy:
   -tls-cert string: path to certificate file
   -tls-key string: path to private key file
   -upstream value: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
+  -upstream-timeout duration: maximum amount of time the server will wait for a response from the upstream (default 30s)
   -validate-url string: Access token validation endpoint
   -version: print version string
 ```

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func main() {
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Var(upstreamCAs, "upstream-ca", "paths to CA roots for the Upstream (target) Server (may be given multiple times, defaults to system trust store).")
 
+	flagSet.Duration("upstream-timeout", DefaultUpstreamTimeout, "maximum amount of time the server will wait for a response from the upstream")
+
 	providerOpenShift := openshift.New()
 	providerOpenShift.Bind(flagSet)
 

--- a/options.go
+++ b/options.go
@@ -20,6 +20,11 @@ import (
 	"github.com/openshift/oauth-proxy/providers/openshift"
 )
 
+const (
+	// DefaultUpstreamTimeout is the maximum duration a network dial to a upstream server for a response.
+	DefaultUpstreamTimeout = 30 * time.Second
+)
+
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
 	ProxyPrefix      string        `flag:"proxy-prefix" cfg:"proxy-prefix"`
@@ -101,6 +106,10 @@ type Options struct {
 	// provider to destroy their single sign-on session.
 	LogoutRedirectURL string `flag:"logout-url" cfg:"logout_url"`
 
+	// Timeout is the maximum duration the server will wait for a response from the upstream server.
+	// Defaults to 30 seconds.
+	Timeout time.Duration `flag:"upstream-timeout" cfg:"upstream_timeout"`
+
 	// internal values that are set after config validation
 	redirectURL       *url.URL
 	proxyURLs         []*url.URL
@@ -137,6 +146,7 @@ func NewOptions() *Options {
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
+		Timeout:             DefaultUpstreamTimeout,
 	}
 }
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -61,6 +61,13 @@ func TestOAuthProxyE2E(t *testing.T) {
 			},
 			pageResult: "URI: /",
 		},
+		"basic-with-timeout": {
+			oauthProxyArgs: []string{
+				"--upstream=http://localhost:8080",
+				"--upstream-timeout=30s",
+			},
+			pageResult: "URI: /",
+		},
 		// Tests a scope that is not valid for SA OAuth client use
 		"scope-full": {
 			oauthProxyArgs: []string{


### PR DESCRIPTION
Currently, there is no support for configuring the timeout between the proxy and the backends, and as such, the default timeout of **30 seconds** is applied (as per Go's standard library defaults). When the timeout occurs, the user will see an "http: proxy error: context canceled" in the logs, and the remote client will receive a **502** error.

The default timeout might not be sufficient for some services, especially as every upstream service differs, and the abrupt connection termination might not be desirable. Typically, most upstream services only send response headers after they have gathered/processed all necessary data.

Thus, add a new command-line switch called `--upstream-timeout`, allowing users to configure the timeout setting.

Related:
- [APPSRE-7875](https://issues.redhat.com/browse/APPSRE-7875)
- [APPSRE-7970](https://issues.redhat.com/browse/APPSRE-7970)

Note: this change is, almost entirely, a backport of a change that was added to the upstream [OAuth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) project some time ago, per:

- PR#1638: [Configure upstream timeout](https://github.com/oauth2-proxy/oauth2-proxy/pull/1638)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>