### PR TITLE
htpasswd: add hot reload

### DIFF
--- a/htpasswd_watcher_test.go
+++ b/htpasswd_watcher_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func NewHtpasswdFromFileTest(path string, onUpdate func()) (*HtpasswdFile, error) {
+	return newHtpasswdFromFileImpl(path, onUpdate)
+}
+
+func TestFileReload(t *testing.T) {
+	htpasswdPath := path.Join(t.TempDir(), "htpasswd")
+	if err := os.WriteFile(htpasswdPath, []byte("testuser:{SHA}PaVBVZkYqAjCQCu6UBL2xgsnZhw="), 0644); err != nil {
+		fmt.Printf("failed to write htpasswd file: %s", err)
+	}
+
+	reloaded := make(chan struct{})
+	htpasswd, err := NewHtpasswdFromFileTest(htpasswdPath, sync.OnceFunc(func() { close(reloaded) }))
+	if err != nil {
+		t.Fatalf("failed to create htpasswd: %s", err)
+	}
+	defer htpasswd.Close()
+
+	valid := htpasswd.Validate("testuser", "asdf")
+	assert.Equal(t, valid, true)
+
+	if err := os.WriteFile(htpasswdPath, []byte("foo:{SHA}rjXz/gOeuoMRiEa7Get6eHtKkX0="), 0644); err != nil {
+		fmt.Printf("failed to update htpasswd file: %s", err)
+	}
+
+	<-reloaded
+
+	valid = htpasswd.Validate("testuser", "asdf")
+	assert.Equal(t, valid, false)
+	valid = htpasswd.Validate("foo", "ghjk")
+	assert.Equal(t, valid, true)
+}

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("FATAL: unable to open %s %s", opts.HtpasswdFile, err)
 		}
+		defer oauthproxy.HtpasswdFile.Close()
 	}
 
 	if opts.DebugAddress != "" {


### PR DESCRIPTION
Allow `HtpasswdFile` to watch and reload new user entries when the file changes. This feature might come handy when someone wants to update the password file without restarting the service.