### PR TITLE
Update image references from sidecar example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ To build, run:
 $ go test .
 ```
 
-The docker images for this repository are built by [the OpenShift release process](https://github.com/openshift/release/blob/master/projects/oauth-proxy/pipeline.yaml) and are available at
+The docker images for this repository are built by [the OpenShift release process](https://github.com/openshift/release/tree/master/ci-operator/config/openshift/oauth-proxy) and are available at
 
 ```
-$ docker pull registry.svc.ci.openshift.org/ci/oauth-proxy:v1
+$ podman pull quay.io/openshift/origin-oauth-proxy:latest
 ```
 
 ## End-to-end testing

--- a/contrib/sidecar.yaml
+++ b/contrib/sidecar.yaml
@@ -50,7 +50,7 @@ items:
         serviceAccountName: proxy
         containers:
         - name: oauth-proxy
-          image: openshift/oauth-proxy:latest
+          image: quay.io/openshift/origin-oauth-proxy:latest
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8443
@@ -66,9 +66,8 @@ items:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: proxy-tls
-
         - name: app
-          image: openshift/hello-openshift:latest
+          image: quay.io/openshift/origin-hello-openshift:latest
         volumes:
         - name: proxy-tls
           secret:


### PR DESCRIPTION
Fixes the image references from the sidecar example to latest on Quay.io 

closes #273 