### PR TITLE
no-jira: OWNERS: add Krzys (ibihim) and Ilias (liouk) as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
-- sttts
-- stlaz
+- ibihim
+- liouk
 
 approvers:
-- sttts
-- stlaz
-- deads2k
+- ibihim


### PR DESCRIPTION
## What

Add to owners:

- ibihim
- liouk

Remove from owners:

- sttts
- stlaz

## Why

sttts and stlaz left the org. ibihim and liouk are the current maintainers.