### PR TITLE
OCPBUGS-44319: Fix oauth-proxy e2e-component tests

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -40,6 +40,7 @@ func TestOAuthProxyE2E(t *testing.T) {
 	routeClient, err := routeclient.NewForConfig(testConfig)
 	require.NoError(t, err)
 	userClient, err := userclient.NewForConfig(testConfig)
+	require.NoError(t, err)
 	ns := CreateTestProject(t, kubeClient, projectClient)
 	defer func() {
 		if len(os.Getenv("DEBUG_TEST")) > 0 {
@@ -187,18 +188,9 @@ func TestOAuthProxyE2E(t *testing.T) {
 		// },
 	}
 
-	// Get the image from a pod that we know uses oauth-proxy to wrap
-	// its endpoints with OpenShift auth
-	// TODO: is there a better way?
-	alertmanagerPod, err := kubeClient.CoreV1().Pods("openshift-monitoring").Get(testCtx, "alertmanager-main-0", metav1.GetOptions{})
-	require.NoError(t, err)
-	var image string
-	for _, c := range alertmanagerPod.Spec.Containers {
-		if c.Name == "alertmanager-proxy" {
-			image = c.Image
-		}
-	}
-	require.NotEmpty(t, image)
+	registry := strings.Split(os.Getenv("RELEASE_IMAGE_LATEST"), "/")[0]
+	require.NotEmpty(t, registry)
+	image := registry + "/" + os.Getenv("NAMESPACE") + "/pipeline:oauth-proxy"
 
 	// get rid of kubeadmin user to remove the additional step of choosing an idp
 	err = kubeClient.CoreV1().Secrets("kube-system").Delete(context.TODO(), "kubeadmin", metav1.DeleteOptions{})

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -187,11 +187,16 @@ func TestOAuthProxyE2E(t *testing.T) {
 		// 	expectedErr: "did not reach upstream site",
 		// },
 	}
-
 	registry := strings.Split(os.Getenv("RELEASE_IMAGE_LATEST"), "/")[0]
-	require.NotEmpty(t, registry)
-	image := registry + "/" + os.Getenv("NAMESPACE") + "/pipeline:oauth-proxy"
+	require.NotEmpty(t, registry, "Registry is empty. Check RELEASE_IMAGE_LATEST environment variable.")
+	namespace := os.Getenv("NAMESPACE")
+	require.NotEmpty(t, namespace, "Namespace is empty. Check NAMESPACE environment variable.")
+	image := registry + "/" + namespace + "/pipeline:oauth-proxy"
 
+	// Print values for debugging
+	fmt.Println("Registry:", registry)
+	fmt.Println("Namespace:", namespace)
+	fmt.Println("Image:", image)
 	// get rid of kubeadmin user to remove the additional step of choosing an idp
 	err = kubeClient.CoreV1().Secrets("kube-system").Delete(context.TODO(), "kubeadmin", metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -193,10 +193,6 @@ func TestOAuthProxyE2E(t *testing.T) {
 	require.NotEmpty(t, namespace, "Namespace is empty. Check NAMESPACE environment variable.")
 	image := registry + "/" + namespace + "/pipeline:oauth-proxy"
 
-	// Print values for debugging
-	fmt.Println("Registry:", registry)
-	fmt.Println("Namespace:", namespace)
-	fmt.Println("Image:", image)
 	// get rid of kubeadmin user to remove the additional step of choosing an idp
 	err = kubeClient.CoreV1().Secrets("kube-system").Delete(context.TODO(), "kubeadmin", metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
- We’re unable to find a stable and accessible OAuth-proxy image, which is causing a bug that we haven’t fully resolved yet. @ibihim  made a PR to address this , but it’s not a complete solution since the image path doesn’t seem consistently available.
- @ibihim  tried referencing the OAuth-proxy image from the OpenShift openshift namespace, but it didn’t work reliably.
- There’s an imagestream for OAuth-proxy in the openshift namespace, which we might be able to reference in tests, but you're not certain of the correct Docker URL format for it. Also, it’s possible that there are permission issues, which could be why the image isn’t accessible when referenced this way.