### PR TITLE
NO-JIRA: Updating golang-github-openshift-oauth-proxy-container image to be consistent with ART for 4.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR  /go/src/github.com/openshift/oauth-proxy
 COPY . .
 RUN go build .


### PR DESCRIPTION
## Summary

This PR is a rebased version of #271, which was stuck due to `e2e-component` test failures.

- Cherry-picked the original commit from #271 (authored by AOS Automation Release Team)
- Rebased onto current `release-4.16` which includes the e2e-component test fix (bf6476f6)

**Original PR**: #271
**Original Author**: AOS Automation Release Team (openshift-bot)

## Change

Updates the Dockerfile builder image from Go 1.20 to Go 1.21 for OpenShift 4.16 ART consistency.

```diff
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
```

## Context

Reconciling with https://github.com/openshift/ocp-build-data/tree/b7ba6c3881993b1c2e0a96905cce738d604e1f1d/images/golang-github-openshift-oauth-proxy.yml

/cc @openshift-bot