### PR TITLE
Updating golang-github-openshift-oauth-proxy-container image to be consistent with ART for 4.12

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR  /go/src/github.com/openshift/oauth-proxy
 COPY . .
 RUN go build .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.12
 COPY --from=builder /go/src/github.com/openshift/oauth-proxy/oauth-proxy /usr/bin/oauth-proxy
 ENTRYPOINT ["/usr/bin/oauth-proxy"]

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -826,7 +826,8 @@ func (st *SignatureTest) Close() {
 
 // fakeNetConn simulates an http.Request.Body buffer that will be consumed
 // when it is read by the hmacauth.HmacAuth if not handled properly. See:
-//   https://github.com/18F/hmacauth/pull/4
+//
+//	https://github.com/18F/hmacauth/pull/4
 type fakeNetConn struct {
 	reqBody string
 }


### PR DESCRIPTION
Fixes gofmt for Go 1.19 doc comment formatting and includes ART image update for 4.12.

Go 1.19 changed `gofmt` rules requiring URLs in doc comment blocks to be on their own indented line.
This was causing `ci/prow/verify` to fail on the original ART PR.

Replaces #351.