### PR TITLE
OCPBUGS-100053: add header normalization for forwarded auth headers

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -807,15 +807,15 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	// At this point, the user is authenticated. proxy normally
 	if p.PassBasicAuth {
 		req.SetBasicAuth(session.User, p.BasicAuthPassword)
-		req.Header["X-Forwarded-User"] = []string{session.User}
+		setRequestHeader(req, "X-Forwarded-User", session.User)
 		if session.Email != "" {
-			req.Header["X-Forwarded-Email"] = []string{session.Email}
+			setRequestHeader(req, "X-Forwarded-Email", session.Email)
 		}
 	}
 	if p.PassUserHeaders {
-		req.Header["X-Forwarded-User"] = []string{session.User}
+		setRequestHeader(req, "X-Forwarded-User", session.User)
 		if session.Email != "" {
-			req.Header["X-Forwarded-Email"] = []string{session.Email}
+			setRequestHeader(req, "X-Forwarded-Email", session.Email)
 		}
 	}
 	if p.SetXAuthRequest {
@@ -825,7 +825,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		}
 	}
 	if ((!tokenProvidedByClient && p.PassAccessToken) || (tokenProvidedByClient && p.PassUserBearerToken)) && session.AccessToken != "" {
-		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}
+		setRequestHeader(req, "X-Forwarded-Access-Token", session.AccessToken)
 	}
 	if session.Email == "" {
 		rw.Header().Set("GAP-Auth", session.User)
@@ -886,4 +886,37 @@ func parseSameSite(v string) http.SameSite {
 	default:
 		panic(fmt.Sprintf("Invalid value for SameSite: %s", v))
 	}
+}
+
+// normalizeHeaderName normalizes the header name by lowercasing it
+// and replacing underscores with hyphens.
+func normalizeHeaderName(headerName string) string {
+	headerName = strings.ToLower(headerName)
+	headerName = strings.ReplaceAll(headerName, "_", "-")
+	return headerName
+}
+
+// stripNormalizedHeader removes any headers from the request that match
+// the normalized version of the provided header's name.
+func stripNormalizedHeader(req *http.Request, headerName string) {
+	normalizedName := normalizeHeaderName(headerName)
+	toBeDeleted := []string{}
+	for h := range req.Header {
+		if normalizeHeaderName(h) == normalizedName {
+			toBeDeleted = append(toBeDeleted, h)
+		}
+	}
+	for _, h := range toBeDeleted {
+		delete(req.Header, h)
+	}
+}
+
+// setRequestHeader strips all normalized variants of a header name from the request
+// and then sets the header to the provided value.
+func setRequestHeader(req *http.Request, headerName string, value string) {
+	stripNormalizedHeader(req, headerName)
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	req.Header[headerName] = []string{value}
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -334,11 +334,25 @@ func TestBasicAuthPassword(t *testing.T) {
 	})
 	req.AddCookie(proxy.MakeCSRFCookie(req, "nonce", proxy.CookieExpire, time.Now()))
 
+	// Add header variants with underscores to verify normalization
+	req.Header.Set("X-Forwarded_User", "variant_user")
+	req.Header.Set("X-Forwarded_Email", "variant@example.com")
+
 	rw = httptest.NewRecorder()
 	proxy.ServeHTTP(rw, req)
 
 	expectedHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(user_name+":"+opts.BasicAuthPassword))
 	assert.Equal(t, expectedHeader, rw.Body.String())
+
+	// Verify underscore variants were normalized and replaced with authenticated values
+	assert.Equal(t, user_name, req.Header.Get("X-Forwarded-User"))
+	assert.Equal(t, email_address, req.Header.Get("X-Forwarded-Email"))
+	// Verify no underscore variants remain after normalization
+	_, hasUnderscore := req.Header["X-Forwarded_User"]
+	assert.Equal(t, false, hasUnderscore)
+	_, hasUnderscore = req.Header["X-Forwarded_Email"]
+	assert.Equal(t, false, hasUnderscore)
+
 	provider_server.Close()
 }
 
@@ -939,4 +953,225 @@ func TestRequestSignaturePostRequest(t *testing.T) {
 	st.MakeRequestWithExpectedKey("POST", payload, "foobar")
 	assert.Equal(t, 200, st.rw.Code)
 	assert.Equal(t, st.rw.Body.String(), "signatures match")
+}
+
+func Test_normalizeHeaderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "lowercase with hyphens",
+			input:    "x-forwarded-user",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "uppercase with hyphens",
+			input:    "X-Forwarded-User",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "mixed case with hyphens",
+			input:    "X-FoRwArDeD-UsEr",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "underscores instead of hyphens",
+			input:    "X_Forwarded_User",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "mixed underscores and hyphens",
+			input:    "X-Forwarded_User",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "all uppercase with underscores",
+			input:    "X_FORWARDED_USER",
+			expected: "x-forwarded-user",
+		},
+		{
+			name:     "all lowercase with underscores",
+			input:    "x_forwarded_user",
+			expected: "x-forwarded-user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeHeaderName(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_setRequestHeader(t *testing.T) {
+	tests := []struct {
+		name            string
+		headerName      string
+		headerValue     string
+		initialHeaders  http.Header
+		expectedHeaders http.Header
+	}{
+		{
+			name:        "set header on empty request",
+			headerName:  "X-Forwarded-User",
+			headerValue: "alice",
+			initialHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type":     {"application/json"},
+				"X-Forwarded-User": {"alice"},
+			},
+		},
+		{
+			name:        "override existing header",
+			headerName:  "X-Forwarded-User",
+			headerValue: "alice",
+			initialHeaders: http.Header{
+				"X-Forwarded-User": {"bob"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type":     {"application/json"},
+				"X-Forwarded-User": {"alice"},
+			},
+		},
+		{
+			name:        "strip underscore variant before setting",
+			headerName:  "X-Forwarded-User",
+			headerValue: "alice",
+			initialHeaders: http.Header{
+				"X-Forwarded_User": {"bob"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type":     {"application/json"},
+				"X-Forwarded-User": {"alice"},
+			},
+		},
+		{
+			name:        "strip all variants before setting",
+			headerName:  "X-Forwarded-User",
+			headerValue: "alice",
+			initialHeaders: http.Header{
+				"X-Forwarded-User": {"bob"},
+				"X-Forwarded_User": {"charlie"},
+				"x-forwarded-user": {"dave"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type":     {"application/json"},
+				"X-Forwarded-User": {"alice"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header = tt.initialHeaders
+
+			setRequestHeader(req, tt.headerName, tt.headerValue)
+
+			require.Equal(t, tt.expectedHeaders, req.Header)
+		})
+	}
+}
+
+func Test_stripNormalizedHeader(t *testing.T) {
+	tests := []struct {
+		name            string
+		headerToStrip   string
+		initialHeaders  http.Header
+		expectedHeaders http.Header
+	}{
+		{
+			name:          "strip exact match",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"X-Forwarded-User": {"user1"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			},
+		},
+		{
+			name:          "strip underscore variant",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"X-Forwarded_User": {"user2"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			},
+		},
+		{
+			name:          "strip mixed case variant",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"x-forwarded-user": {"user3"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			},
+		},
+		{
+			name:          "strip all variants",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"X-Forwarded-User": {"user1"},
+				"X-Forwarded_User": {"user2"},
+				"x-forwarded-user": {"user3"},
+				"X_FORWARDED_USER": {"user4"},
+				"Content-Type":     {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			},
+		},
+		{
+			name:          "preserve other headers",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"X-Forwarded-User":  {"user1"},
+				"X-Forwarded-Email": {"user@example.com"},
+				"Authorization":     {"Bearer token"},
+				"Content-Type":      {"application/json"},
+			},
+			expectedHeaders: http.Header{
+				"X-Forwarded-Email": {"user@example.com"},
+				"Authorization":     {"Bearer token"},
+				"Content-Type":      {"application/json"},
+			},
+		},
+		{
+			name:          "no matching headers to strip",
+			headerToStrip: "X-Forwarded-User",
+			initialHeaders: http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {"Bearer token"},
+			},
+			expectedHeaders: http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {"Bearer token"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header = tt.initialHeaders
+
+			stripNormalizedHeader(req, tt.headerToStrip)
+
+			require.Equal(t, tt.expectedHeaders, req.Header)
+		})
+	}
 }


### PR DESCRIPTION
implement header name normalization to handle header name variants consistently. headers are now normalized to lowercase with hyphens replacing underscores before processing.

all header variants are now stripped before authenticated headers are set, ensuring only the canonical header names are forwarded.