### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 reviewers:
+- control-plane-approvers
 - ibihim
 - liouk
 
 approvers:
+- control-plane-approvers
 - ibihim

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project review and approval coverage to include the designated control-plane approval group.
  * Added the associated approver contacts to support consistent code review routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->